### PR TITLE
Updated j2735_convertor and control_message_test to use new message t…

### DIFF
--- a/carma-messenger-core/docker/checkout.bash
+++ b/carma-messenger-core/docker/checkout.bash
@@ -39,6 +39,6 @@ if [[ "$BRANCH" = "develop" ]]; then
       git clone https://github.com/usdot-fhwa-stol/carma-msgs.git ~/src/CARMAMsgs --branch $BRANCH --depth 1
       git clone https://github.com/usdot-fhwa-stol/carma-utils.git ~/src/CARMAUtils --branch $BRANCH --depth 1
 else
-      git clone https://github.com/usdot-fhwa-stol/carma-msgs.git ${dir}/src/CARMAMsgs --branch develop --depth 1
+      git clone https://github.com/usdot-fhwa-stol/carma-msgs.git ${dir}/src/CARMAMsgs --branch integration/geofence_msg --depth 1
       git clone https://github.com/usdot-fhwa-stol/carma-utils.git ${dir}/src/CARMAUtils --branch develop --depth 1
 fi

--- a/carma-messenger-core/j2735_convertor/include/j2735_convertor/control_message_convertor.h
+++ b/carma-messenger-core/j2735_convertor/include/j2735_convertor/control_message_convertor.h
@@ -18,6 +18,10 @@
 #include <cstdint>
 #include <j2735_msgs/ControlMessage.h>
 #include <cav_msgs/ControlMessage.h>
+#include <j2735_msgs/TrafficControlMessage.h>
+#include <cav_msgs/TrafficControlMessage.h>
+#include <cav_msgs/OffsetPoint.h>
+
 #include "units.h"
 #include "value_convertor.h"
 
@@ -85,6 +89,116 @@ void convert(const j2735_msgs::DaySchedule& in_msg, cav_msgs::DaySchedule& out_m
  */
 void convert(const j2735_msgs::Point& in_msg, cav_msgs::Point& out_msg);
 
+/**
+ * @brief Convert the contents of a j2735_msgs::DailySchedule into a cav_msgs::DailySchedule
+ *
+ * @param in_msg The message to be converted
+ * @param out_msg The message to store the output
+ *
+ * Unit conversions and presence flags are handled
+ */
+void convert(const j2735_msgs::DailySchedule& in_msg, cav_msgs::DailySchedule& out_msg);
+
+/**
+ * @brief Convert the contents of a j2735_msgs::OffsetPoint into a cav_msgs::OffsetPoint
+ *
+ * @param in_msg The message to be converted
+ * @param out_msg The message to store the output
+ *
+ * Unit conversions and presence flags are handled
+ */
+void convert(const j2735_msgs::OffsetPoint& in_msg, cav_msgs::OffsetPoint& out_msg);
+
+/**
+ * @brief Convert the contents of a j2735_msgs::PathNode into a cav_msgs::PathNode
+ *
+ * @param in_msg The message to be converted
+ * @param out_msg The message to store the output
+ *
+ * Unit conversions and presence flags are handled
+ */
+void convert(const j2735_msgs::PathNode& in_msg, cav_msgs::PathNode& out_msg);
+
+/**
+ * @brief Convert the contents of a j2735_msgs::RepeatParams into a cav_msgs::RepeatParams
+ *
+ * @param in_msg The message to be converted
+ * @param out_msg The message to store the output
+ *
+ * Unit conversions and presence flags are handled
+ */
+void convert(const j2735_msgs::RepeatParams& in_msg, cav_msgs::RepeatParams& out_msg);
+
+/**
+ * @brief Convert the contents of a j2735_msgs::TrafficControlBounds into a cav_msgs::TrafficControlBounds
+ *
+ * @param in_msg The message to be converted
+ * @param out_msg The message to store the output
+ *
+ * Unit conversions and presence flags are handled
+ */
+void convert(const j2735_msgs::TrafficControlBounds& in_msg, cav_msgs::TrafficControlBounds& out_msg);
+
+/**
+ * @brief Convert the contents of a j2735_msgs::TrafficControlDetail into a cav_msgs::TrafficControlDetail
+ *
+ * @param in_msg The message to be converted
+ * @param out_msg The message to store the output
+ *
+ * Unit conversions and presence flags are handled
+ */
+void convert(const j2735_msgs::TrafficControlDetail& in_msg, cav_msgs::TrafficControlDetail& out_msg);
+
+/**
+ * @brief Convert the contents of a j2735_msgs::TrafficControlGeometry into a cav_msgs::TrafficControlGeometry
+ *
+ * @param in_msg The message to be converted
+ * @param out_msg The message to store the output
+ *
+ * Unit conversions and presence flags are handled
+ */
+void convert(const j2735_msgs::TrafficControlGeometry& in_msg, cav_msgs::TrafficControlGeometry& out_msg);
+
+/**
+ * @brief Convert the contents of a j2735_msgs::TrafficControlMessage into a cav_msgs::TrafficControlMessage
+ *
+ * @param in_msg The message to be converted
+ * @param out_msg The message to store the output
+ *
+ * Unit conversions and presence flags are handled
+ */
+void convert(const j2735_msgs::TrafficControlMessage& in_msg, cav_msgs::TrafficControlMessage& out_msg);
+
+/**
+ * @brief Convert the contents of a j2735_msgs::TrafficControlMessageV01 into a cav_msgs::TrafficControlMessageV01
+ *
+ * @param in_msg The message to be converted
+ * @param out_msg The message to store the output
+ *
+ * Unit conversions and presence flags are handled
+ */
+void convert(const j2735_msgs::TrafficControlMessageV01& in_msg, cav_msgs::TrafficControlMessageV01& out_msg);
+
+/**
+ * @brief Convert the contents of a j2735_msgs::TrafficControlParams into a cav_msgs::TrafficControlParams
+ *
+ * @param in_msg The message to be converted
+ * @param out_msg The message to store the output
+ *
+ * Unit conversions and presence flags are handled
+ */
+void convert(const j2735_msgs::TrafficControlParams& in_msg, cav_msgs::TrafficControlParams& out_msg);
+
+/**
+ * @brief Convert the contents of a j2735_msgs::TrafficControlSchedule into a cav_msgs::TrafficControlSchedule
+ *
+ * @param in_msg The message to be converted
+ * @param out_msg The message to store the output
+ *
+ * Unit conversions and presence flags are handled
+ */
+void convert(const j2735_msgs::TrafficControlSchedule& in_msg, cav_msgs::TrafficControlSchedule& out_msg);
+
 ////
 // Convert cav_msgs to j2735_msgs
 ////
@@ -138,5 +252,115 @@ void convert(const cav_msgs::DaySchedule& in_msg, j2735_msgs::DaySchedule& out_m
  * Unit conversions and presence flags are handled
  */
 void convert(const cav_msgs::Point& in_msg, j2735_msgs::Point& out_msg);
+
+/**
+ * @brief Convert the contents of a cav_msgs::DailySchedule into a j2735_msgs::DailySchedule
+ *
+ * @param in_msg The message to be converted
+ * @param out_msg The message to store the output
+ *
+ * Unit conversions and presence flags are handled
+ */
+void convert(const cav_msgs::DailySchedule& in_msg, j2735_msgs::DailySchedule& out_msg);
+
+/**
+ * @brief Convert the contents of a cav_msgs::OffsetPoint into a j2735_msgs::OffsetPoint
+ *
+ * @param in_msg The message to be converted
+ * @param out_msg The message to store the output
+ *
+ * Unit conversions and presence flags are handled
+ */
+void convert(const cav_msgs::OffsetPoint& in_msg, j2735_msgs::OffsetPoint& out_msg);
+
+/**
+ * @brief Convert the contents of a cav_msgs::PathNode into a j2735_msgs::PathNode
+ *
+ * @param in_msg The message to be converted
+ * @param out_msg The message to store the output
+ *
+ * Unit conversions and presence flags are handled
+ */
+void convert(const cav_msgs::PathNode& in_msg, j2735_msgs::PathNode& out_msg);
+
+/**
+ * @brief Convert the contents of a cav_msgs::RepeatParams into a j2735_msgs::RepeatParams
+ *
+ * @param in_msg The message to be converted
+ * @param out_msg The message to store the output
+ *
+ * Unit conversions and presence flags are handled
+ */
+void convert(const cav_msgs::RepeatParams& in_msg, j2735_msgs::RepeatParams& out_msg);
+
+/**
+ * @brief Convert the contents of a cav_msgs::TrafficControlBounds into a j2735_msgs::TrafficControlBounds
+ *
+ * @param in_msg The message to be converted
+ * @param out_msg The message to store the output
+ *
+ * Unit conversions and presence flags are handled
+ */
+void convert(const cav_msgs::TrafficControlBounds& in_msg, j2735_msgs::TrafficControlBounds& out_msg);
+
+/**
+ * @brief Convert the contents of a cav_msgs::TrafficControlDetail into a j2735_msgs::TrafficControlDetail
+ *
+ * @param in_msg The message to be converted
+ * @param out_msg The message to store the output
+ *
+ * Unit conversions and presence flags are handled
+ */
+void convert(const cav_msgs::TrafficControlDetail& in_msg, j2735_msgs::TrafficControlDetail& out_msg);
+
+/**
+ * @brief Convert the contents of a cav_msgs::TrafficControlGeometry into a j2735_msgs::TrafficControlGeometry
+ *
+ * @param in_msg The message to be converted
+ * @param out_msg The message to store the output
+ *
+ * Unit conversions and presence flags are handled
+ */
+void convert(const cav_msgs::TrafficControlGeometry& in_msg, j2735_msgs::TrafficControlGeometry& out_msg);
+
+/**
+ * @brief Convert the contents of a cav_msgs::TrafficControlMessage into a j2735_msgs::TrafficControlMessage
+ *
+ * @param in_msg The message to be converted
+ * @param out_msg The message to store the output
+ *
+ * Unit conversions and presence flags are handled
+ */
+void convert(const cav_msgs::TrafficControlMessage& in_msg, j2735_msgs::TrafficControlMessage& out_msg);
+
+/**
+ * @brief Convert the contents of a cav_msgs::TrafficControlMessageV01 into a j2735_msgs::TrafficControlMessageV01
+ *
+ * @param in_msg The message to be converted
+ * @param out_msg The message to store the output
+ *
+ * Unit conversions and presence flags are handled
+ */
+void convert(const cav_msgs::TrafficControlMessageV01& in_msg, j2735_msgs::TrafficControlMessageV01& out_msg);
+
+/**
+ * @brief Convert the contents of a cav_msgs::TrafficControlParams into a j2735_msgs::TrafficControlParams
+ *
+ * @param in_msg The message to be converted
+ * @param out_msg The message to store the output
+ *
+ * Unit conversions and presence flags are handled
+ */
+void convert(const cav_msgs::TrafficControlParams& in_msg, j2735_msgs::TrafficControlParams& out_msg);
+
+/**
+ * @brief Convert the contents of a cav_msgs::TrafficControlSchedule into a j2735_msgs::TrafficControlSchedule
+ *
+ * @param in_msg The message to be converted
+ * @param out_msg The message to store the output
+ *
+ * Unit conversions and presence flags are handled
+ */
+void convert(const cav_msgs::TrafficControlSchedule& in_msg, j2735_msgs::TrafficControlSchedule& out_msg);
 }  // namespace geofence_control
 }  // namespace j2735_convertor

--- a/carma-messenger-core/j2735_convertor/include/j2735_convertor/control_message_convertor.h
+++ b/carma-messenger-core/j2735_convertor/include/j2735_convertor/control_message_convertor.h
@@ -100,16 +100,6 @@ void convert(const j2735_msgs::Point& in_msg, cav_msgs::Point& out_msg);
 void convert(const j2735_msgs::DailySchedule& in_msg, cav_msgs::DailySchedule& out_msg);
 
 /**
- * @brief Convert the contents of a j2735_msgs::OffsetPoint into a cav_msgs::OffsetPoint
- *
- * @param in_msg The message to be converted
- * @param out_msg The message to store the output
- *
- * Unit conversions and presence flags are handled
- */
-void convert(const j2735_msgs::OffsetPoint& in_msg, cav_msgs::OffsetPoint& out_msg);
-
-/**
  * @brief Convert the contents of a j2735_msgs::PathNode into a cav_msgs::PathNode
  *
  * @param in_msg The message to be converted
@@ -128,16 +118,6 @@ void convert(const j2735_msgs::PathNode& in_msg, cav_msgs::PathNode& out_msg);
  * Unit conversions and presence flags are handled
  */
 void convert(const j2735_msgs::RepeatParams& in_msg, cav_msgs::RepeatParams& out_msg);
-
-/**
- * @brief Convert the contents of a j2735_msgs::TrafficControlBounds into a cav_msgs::TrafficControlBounds
- *
- * @param in_msg The message to be converted
- * @param out_msg The message to store the output
- *
- * Unit conversions and presence flags are handled
- */
-void convert(const j2735_msgs::TrafficControlBounds& in_msg, cav_msgs::TrafficControlBounds& out_msg);
 
 /**
  * @brief Convert the contents of a j2735_msgs::TrafficControlDetail into a cav_msgs::TrafficControlDetail
@@ -264,16 +244,6 @@ void convert(const cav_msgs::Point& in_msg, j2735_msgs::Point& out_msg);
 void convert(const cav_msgs::DailySchedule& in_msg, j2735_msgs::DailySchedule& out_msg);
 
 /**
- * @brief Convert the contents of a cav_msgs::OffsetPoint into a j2735_msgs::OffsetPoint
- *
- * @param in_msg The message to be converted
- * @param out_msg The message to store the output
- *
- * Unit conversions and presence flags are handled
- */
-void convert(const cav_msgs::OffsetPoint& in_msg, j2735_msgs::OffsetPoint& out_msg);
-
-/**
  * @brief Convert the contents of a cav_msgs::PathNode into a j2735_msgs::PathNode
  *
  * @param in_msg The message to be converted
@@ -292,16 +262,6 @@ void convert(const cav_msgs::PathNode& in_msg, j2735_msgs::PathNode& out_msg);
  * Unit conversions and presence flags are handled
  */
 void convert(const cav_msgs::RepeatParams& in_msg, j2735_msgs::RepeatParams& out_msg);
-
-/**
- * @brief Convert the contents of a cav_msgs::TrafficControlBounds into a j2735_msgs::TrafficControlBounds
- *
- * @param in_msg The message to be converted
- * @param out_msg The message to store the output
- *
- * Unit conversions and presence flags are handled
- */
-void convert(const cav_msgs::TrafficControlBounds& in_msg, j2735_msgs::TrafficControlBounds& out_msg);
 
 /**
  * @brief Convert the contents of a cav_msgs::TrafficControlDetail into a j2735_msgs::TrafficControlDetail

--- a/carma-messenger-core/j2735_convertor/src/control_message_convertor.cpp
+++ b/carma-messenger-core/j2735_convertor/src/control_message_convertor.cpp
@@ -98,6 +98,275 @@ void convert(const j2735_msgs::Point& in_msg, cav_msgs::Point& out_msg)
   out_msg.z_exists = in_msg.z_exists;
 }
 
+void convert(const j2735_msgs::DailySchedule& in_msg, cav_msgs::DailySchedule& out_msg)
+{
+  out_msg.begin = ros::Duration(in_msg.begin * units::SEC_PER_MIN);
+  out_msg.duration = ros::Duration(in_msg.duration * units::SEC_PER_MIN);
+}
+
+void convert(const j2735_msgs::OffsetPoint& in_msg, cav_msgs::OffsetPoint& out_msg)
+{
+  out_msg.deltax = (double)in_msg.deltax;
+  out_msg.deltay = (double)in_msg.deltay;
+}
+
+void convert(const j2735_msgs::PathNode& in_msg, cav_msgs::PathNode& out_msg)
+{
+  out_msg.x = (double)in_msg.x / units::CM_PER_M;
+  out_msg.y = (double)in_msg.y / units::CM_PER_M;
+
+  out_msg.z_exists = in_msg.z_exists;
+  if(out_msg.z_exists)
+  {
+    out_msg.z = (double)in_msg.z / units::CM_PER_M;
+  }
+
+  out_msg.width_exists = in_msg.width_exists;
+  if(out_msg.width_exists)
+  {
+    out_msg.width = (float)in_msg.width / units::CM_PER_M;
+  }
+}
+
+void convert(const j2735_msgs::RepeatParams& in_msg, cav_msgs::RepeatParams& out_msg)
+{
+  out_msg.offset = ros::Duration(in_msg.offset * units::SEC_PER_MIN);
+  out_msg.period = ros::Duration(in_msg.period * units::SEC_PER_MIN);
+  out_msg.span = ros::Duration(in_msg.span * units::SEC_PER_MIN);
+}
+
+void convert(const j2735_msgs::TrafficControlBounds& in_msg, cav_msgs::TrafficControlBounds& out_msg)
+{
+  out_msg.oldest = ros::Time(in_msg.oldest * units::SEC_PER_MIN, 0);
+  out_msg.reflon = (double)in_msg.reflon / units::TENTH_MICRO_DEG_PER_DEG;
+  out_msg.reflat = (double)in_msg.reflat / units::TENTH_MICRO_DEG_PER_DEG;
+
+  for(int i = 0; i < 3; i++)
+  {
+    convert(in_msg.offsets[i], out_msg.offsets[i]);
+  }
+}
+
+void convert(const j2735_msgs::TrafficControlDetail& in_msg, cav_msgs::TrafficControlDetail& out_msg)
+{
+  out_msg.choice = in_msg.choice;
+  switch(in_msg.choice)
+  {
+    case j2735_msgs::TrafficControlDetail::SIGNAL_CHOICE : 
+      out_msg.signal = in_msg.signal;
+      break;
+    case j2735_msgs::TrafficControlDetail::STOP_CHOICE : 
+      // Not implemented yet
+      break;
+    case j2735_msgs::TrafficControlDetail::YIELD_CHOICE : 
+      // Not implemented yet
+      break;
+    case j2735_msgs::TrafficControlDetail::NOTOWING_CHOICE : 
+      // Not implemented yet
+      break;
+    case j2735_msgs::TrafficControlDetail::RESTRICTED_CHOICE : 
+      // Not implemented yet
+      break;
+    case j2735_msgs::TrafficControlDetail::CLOSED_CHOICE : 
+      out_msg.closed = in_msg.closed;
+      break;
+    case j2735_msgs::TrafficControlDetail::CHAINS_CHOICE : 
+      out_msg.chains = in_msg.chains;
+      break;
+    case j2735_msgs::TrafficControlDetail::DIRECTION_CHOICE : 
+      out_msg.direction = in_msg.direction;
+      break;
+    case j2735_msgs::TrafficControlDetail::LATAFFINITY_CHOICE : 
+      out_msg.lataffinity = in_msg.lataffinity;
+      break;
+    case j2735_msgs::TrafficControlDetail::LATPERM_CHOICE : 
+      for(int i = 0; i < 2; i++)
+      {
+        out_msg.latperm[i] = in_msg.latperm[i];
+      }
+      break;
+    case j2735_msgs::TrafficControlDetail::PARKING_CHOICE : 
+      out_msg.parking = in_msg.parking;
+      break;
+    case j2735_msgs::TrafficControlDetail::MINSPEED_CHOICE : 
+      out_msg.minspeed = (float)in_msg.minspeed / units::DECA_MPS_PER_MPS;
+      break;
+    case j2735_msgs::TrafficControlDetail::MAXSPEED_CHOICE : 
+      out_msg.maxspeed = (float)in_msg.maxspeed / units::DECA_MPS_PER_MPS;
+      break;
+    case j2735_msgs::TrafficControlDetail::MINHDWY_CHOICE : 
+      out_msg.minhdwy = (float)in_msg.minhdwy / units::DECA_M_PER_M;
+      break;
+    case j2735_msgs::TrafficControlDetail::MAXVEHMASS_CHOICE : 
+      out_msg.maxvehmass = (float)in_msg.maxvehmass;
+      break;
+    case j2735_msgs::TrafficControlDetail::MAXVEHHEIGHT_CHOICE : 
+      out_msg.maxvehheight = (float)in_msg.maxvehheight / units::DECA_M_PER_M;
+      break;
+    case j2735_msgs::TrafficControlDetail::MAXVEHWIDTH_CHOICE : 
+      out_msg.maxvehwidth = (float)in_msg.maxvehwidth / units::DECA_M_PER_M;
+      break;
+    case j2735_msgs::TrafficControlDetail::MAXVEHLENGTH_CHOICE : 
+      out_msg.maxvehlength = (float)in_msg.maxvehlength / units::DECA_M_PER_M;
+      break;
+    case j2735_msgs::TrafficControlDetail::MAXVEHAXLES_CHOICE : 
+      out_msg.maxvehaxles = in_msg.maxvehaxles;
+      break;
+    case j2735_msgs::TrafficControlDetail::MINVEHOCC_CHOICE : 
+      out_msg.minvehocc = in_msg.minvehocc;
+      break;
+    
+  }
+}
+
+void convert(const j2735_msgs::TrafficControlGeometry& in_msg, cav_msgs::TrafficControlGeometry& out_msg)
+{
+  out_msg.proj = in_msg.proj;
+  out_msg.datum = in_msg.datum;
+  out_msg.reftime = ros::Time(in_msg.reftime * units::SEC_PER_MIN, 0);
+  out_msg.reflon = (double)in_msg.reflon / units::TENTH_MICRO_DEG_PER_DEG;
+  out_msg.reflat = (double)in_msg.reflat / units::TENTH_MICRO_DEG_PER_DEG;
+  out_msg.refelv = (float)in_msg.refelv / units::DECA_M_PER_M;
+  out_msg.heading = (float)in_msg.heading / units::DECA_S_PER_S;
+
+  for (auto in_node : in_msg.nodes)
+  {
+    cav_msgs::PathNode out_node;
+    convert(in_node, out_node);
+    out_msg.nodes.push_back(out_node);
+  }
+}
+
+void convert(const j2735_msgs::TrafficControlMessage& in_msg, cav_msgs::TrafficControlMessage& out_msg)
+{
+  // uint8 choice
+  out_msg.choice = in_msg.choice;
+  switch(in_msg.choice)
+  {
+    case j2735_msgs::TrafficControlMessage::RESERVED : 
+      // Not implemented yet
+      break;
+    case j2735_msgs::TrafficControlMessage::TCMV01 : 
+      convert(in_msg.tcmV01, out_msg.tcmV01);
+      break;
+  }
+}
+
+void convert(const j2735_msgs::TrafficControlMessageV01& in_msg, cav_msgs::TrafficControlMessageV01& out_msg)
+{
+  // # reqid ::= Id64b
+  // uint8[8] reqid
+  out_msg.reqid = in_msg.reqid;
+
+  // # reqseq ::= INTEGER (0..255)
+  // uint8 reqseq
+  out_msg.reqseq = in_msg.reqseq;
+
+  // # msgtot INTEGER (0..65535), -- total expected traffic control message responses
+  // uint16 msgtot
+  out_msg.msgtot = in_msg.msgtot;
+
+  // # msgnum INTEGER (0..65535), -- message index for each response out of total responses
+  // uint16 msgnum
+  out_msg.msgnum = in_msg.msgnum;
+
+  // # id Id128b, -- unique traffic control id
+  // uint8[16] id
+  out_msg.id = in_msg.id;
+
+  // # updated EpochMins
+  // time updated
+  out_msg.updated = ros::Time(in_msg.updated * units::SEC_PER_MIN, 0);
+
+  // # package [0] TrafficControlPackage OPTIONAL, -- related traffic control ids
+  // j2735_msgs/TrafficControlPackage package
+  // bool package_exists
+  out_msg.package_exists = in_msg.package_exists;
+  if(out_msg.package_exists)
+  {
+    out_msg.package = in_msg.package;
+  }
+
+  // # params [1] TrafficControlParams OPTIONAL
+  // cav_msgs/TrafficControlParams params
+  // bool params_exists
+  out_msg.params_exists = in_msg.params_exists;
+  if(out_msg.params_exists)
+  {
+    convert(in_msg.params, out_msg.params);
+  }
+
+  // # geometry [2] TrafficControlGeometry OPTIONAL
+  // cav_msgs/TrafficControlGeometry geometry
+  // bool geometry_exists
+  out_msg.geometry_exists = in_msg.geometry_exists;
+  if(out_msg.geometry_exists)
+  {
+    convert(in_msg.geometry, out_msg.geometry);
+  }
+
+  // # Bounds SEQUENCE (SIZE(1..63)) OF TrafficControlBounds
+  // cav_msgs/TrafficControlBounds[] bounds
+  for (auto in_bound : in_msg.bounds)
+  {
+    cav_msgs::TrafficControlBounds out_bound;
+    convert(in_bound, out_bound);
+    out_msg.bounds.push_back(out_bound);
+  }
+}
+
+void convert(const j2735_msgs::TrafficControlParams& in_msg, cav_msgs::TrafficControlParams& out_msg)
+{
+  // j2735_msgs/TrafficControlVehClass[] vclasses
+  out_msg.vclasses = in_msg.vclasses;
+  
+  // # schedule TrafficControlSchedule
+  // cav_msgs/TrafficControlSchedule schedule
+  convert(in_msg.schedule, out_msg.schedule);
+
+  // # regulatory BOOLEAN
+  // bool regulatory
+  out_msg.regulatory = in_msg.regulatory;
+
+  // # detail TrafficControlDetail
+  // cav_msgs/TrafficControlDetail detail
+  convert(in_msg.detail, out_msg.detail);
+}
+
+void convert(const j2735_msgs::TrafficControlSchedule& in_msg, cav_msgs::TrafficControlSchedule& out_msg)
+{
+  out_msg.start = ros::Time(in_msg.start * units::SEC_PER_MIN, 0);
+
+  out_msg.end_exists = in_msg.end_exists;
+  if(out_msg.end_exists)
+  {
+    out_msg.end = ros::Time(in_msg.end * units::SEC_PER_MIN, 0);
+  }
+
+  out_msg.dow_exists = in_msg.dow_exists;
+  if(out_msg.dow_exists)
+  {
+    out_msg.dow = in_msg.dow;
+  }
+
+  out_msg.between_exists = in_msg.between_exists;
+  if(out_msg.between_exists)
+  {
+    for (auto in_between : in_msg.between)
+    {
+      cav_msgs::DailySchedule out_between;
+      convert(in_between, out_between);
+      out_msg.between.push_back(out_between);
+    }
+  }
+
+  out_msg.repeat_exists = in_msg.repeat_exists;
+  if(out_msg.repeat_exists)
+  {
+    convert(in_msg.repeat, out_msg.repeat);
+  }
+}
+
 ////
 // Convert cav_msgs to j2735_msgs
 ////
@@ -173,6 +442,274 @@ void convert(const cav_msgs::Point& in_msg, j2735_msgs::Point& out_msg)
                                            // checking z_exists flag.
   out_msg.width = in_msg.width * units::CM_PER_M;
   out_msg.z_exists = in_msg.z_exists;
+}
+
+void convert(const cav_msgs::DailySchedule& in_msg, j2735_msgs::DailySchedule& out_msg)
+{
+  out_msg.begin = in_msg.begin.toSec() / units::SEC_PER_MIN;
+  out_msg.duration = in_msg.duration.toSec() / units::SEC_PER_MIN;
+}
+
+void convert(const cav_msgs::OffsetPoint& in_msg, j2735_msgs::OffsetPoint& out_msg)
+{
+  out_msg.deltax = (int16_t)in_msg.deltax;
+  out_msg.deltay = (int16_t)in_msg.deltay;
+}
+
+void convert(const cav_msgs::PathNode& in_msg, j2735_msgs::PathNode& out_msg)
+{
+  out_msg.x = (int16_t)(in_msg.x * units::CM_PER_M);
+  out_msg.y = (int16_t)(in_msg.y * units::CM_PER_M);
+
+  out_msg.z_exists = in_msg.z_exists;
+  if(out_msg.z_exists)
+  {
+    out_msg.z = (int16_t)(in_msg.z * units::CM_PER_M);
+  }
+
+  out_msg.width_exists = in_msg.width_exists;
+  if(out_msg.width_exists)
+  {
+    out_msg.width = (int8_t)(in_msg.width * units::CM_PER_M);
+  }
+}
+
+void convert(const cav_msgs::RepeatParams& in_msg, j2735_msgs::RepeatParams& out_msg)
+{
+  out_msg.offset = in_msg.offset.toSec() / units::SEC_PER_MIN;
+  out_msg.period = in_msg.period.toSec() / units::SEC_PER_MIN;
+  out_msg.span = in_msg.span.toSec() / units::SEC_PER_MIN;
+}
+
+void convert(const cav_msgs::TrafficControlBounds& in_msg, j2735_msgs::TrafficControlBounds& out_msg)
+{
+  out_msg.oldest = in_msg.oldest.toSec() / units::SEC_PER_MIN;
+  out_msg.reflon = (int32_t)(in_msg.reflon * units::TENTH_MICRO_DEG_PER_DEG);
+  out_msg.reflat = (int32_t)(in_msg.reflat * units::TENTH_MICRO_DEG_PER_DEG);
+
+  for(int i = 0; i < 3; i++)
+  {
+    convert(in_msg.offsets[i], out_msg.offsets[i]);
+  }
+}
+
+void convert(const cav_msgs::TrafficControlDetail& in_msg, j2735_msgs::TrafficControlDetail& out_msg)
+{
+  out_msg.choice = in_msg.choice;
+  switch(in_msg.choice)
+  {
+    case cav_msgs::TrafficControlDetail::SIGNAL_CHOICE : 
+      out_msg.signal = in_msg.signal;
+      break;
+    case cav_msgs::TrafficControlDetail::STOP_CHOICE : 
+      // Not implemented yet
+      break;
+    case cav_msgs::TrafficControlDetail::YIELD_CHOICE : 
+      // Not implemented yet
+      break;
+    case cav_msgs::TrafficControlDetail::NOTOWING_CHOICE : 
+      // Not implemented yet
+      break;
+    case cav_msgs::TrafficControlDetail::RESTRICTED_CHOICE : 
+      // Not implemented yet
+      break;
+    case cav_msgs::TrafficControlDetail::CLOSED_CHOICE : 
+      out_msg.closed = in_msg.closed;
+      break;
+    case cav_msgs::TrafficControlDetail::CHAINS_CHOICE : 
+      out_msg.chains = in_msg.chains;
+      break;
+    case cav_msgs::TrafficControlDetail::DIRECTION_CHOICE : 
+      out_msg.direction = in_msg.direction;
+      break;
+    case cav_msgs::TrafficControlDetail::LATAFFINITY_CHOICE : 
+      out_msg.lataffinity = in_msg.lataffinity;
+      break;
+    case cav_msgs::TrafficControlDetail::LATPERM_CHOICE : 
+      for(int i = 0; i < 2; i++)
+      {
+        out_msg.latperm[i] = in_msg.latperm[i];
+      }
+      break;
+    case cav_msgs::TrafficControlDetail::PARKING_CHOICE : 
+      out_msg.parking = in_msg.parking;
+      break;
+    case cav_msgs::TrafficControlDetail::MINSPEED_CHOICE : 
+      out_msg.minspeed = (uint16_t)(in_msg.minspeed * units::DECA_MPS_PER_MPS);
+      break;
+    case cav_msgs::TrafficControlDetail::MAXSPEED_CHOICE : 
+      out_msg.maxspeed = (uint16_t)(in_msg.maxspeed * units::DECA_MPS_PER_MPS);
+      break;
+    case cav_msgs::TrafficControlDetail::MINHDWY_CHOICE : 
+      out_msg.minhdwy = (uint16_t)(in_msg.minhdwy * units::DECA_M_PER_M);
+      break;
+    case cav_msgs::TrafficControlDetail::MAXVEHMASS_CHOICE : 
+      out_msg.maxvehmass = (int16_t)in_msg.maxvehmass;
+      break;
+    case cav_msgs::TrafficControlDetail::MAXVEHHEIGHT_CHOICE : 
+      out_msg.maxvehheight = (uint8_t)(in_msg.maxvehheight * units::DECA_M_PER_M);
+      break;
+    case cav_msgs::TrafficControlDetail::MAXVEHWIDTH_CHOICE : 
+      out_msg.maxvehwidth = (uint8_t)(in_msg.maxvehwidth * units::DECA_M_PER_M);
+      break;
+    case cav_msgs::TrafficControlDetail::MAXVEHLENGTH_CHOICE : 
+      out_msg.maxvehlength = (uint8_t)(in_msg.maxvehlength * units::DECA_M_PER_M);
+      break;
+    case cav_msgs::TrafficControlDetail::MAXVEHAXLES_CHOICE : 
+      out_msg.maxvehaxles = in_msg.maxvehaxles;
+      break;
+    case cav_msgs::TrafficControlDetail::MINVEHOCC_CHOICE : 
+      out_msg.minvehocc = in_msg.minvehocc;
+      break;
+  }
+}
+
+void convert(const cav_msgs::TrafficControlGeometry& in_msg, j2735_msgs::TrafficControlGeometry& out_msg)
+{
+  out_msg.proj = in_msg.proj;
+  out_msg.datum = in_msg.datum;
+  out_msg.reftime = in_msg.reftime.toSec() / units::SEC_PER_MIN;
+  out_msg.reflon = (int32_t)(in_msg.reflon * units::TENTH_MICRO_DEG_PER_DEG);
+  out_msg.reflat = (int32_t)(in_msg.reflat * units::TENTH_MICRO_DEG_PER_DEG);
+  out_msg.refelv = (int32_t)(in_msg.refelv * units::DECA_M_PER_M);
+  out_msg.heading = (int32_t)(in_msg.heading * units::DECA_S_PER_S);
+
+  for (auto in_node : in_msg.nodes)
+  {
+    j2735_msgs::PathNode out_node;
+    convert(in_node, out_node);
+    out_msg.nodes.push_back(out_node);
+  }
+}
+
+void convert(const cav_msgs::TrafficControlMessage& in_msg, j2735_msgs::TrafficControlMessage& out_msg)
+{
+  // uint8 choice
+  out_msg.choice = in_msg.choice;
+  switch(in_msg.choice)
+  {
+    case cav_msgs::TrafficControlMessage::RESERVED : 
+      // Not implemented yet
+      break;
+    case cav_msgs::TrafficControlMessage::TCMV01 : 
+      convert(in_msg.tcmV01, out_msg.tcmV01);
+      break;
+  }
+}
+
+void convert(const cav_msgs::TrafficControlMessageV01& in_msg, j2735_msgs::TrafficControlMessageV01& out_msg)
+{
+  // # reqid ::= Id64b
+  // uint8[8] reqid
+  out_msg.reqid = in_msg.reqid;
+
+  // # reqseq ::= INTEGER (0..255)
+  // uint8 reqseq
+  out_msg.reqseq = in_msg.reqseq;
+
+  // # msgtot INTEGER (0..65535), -- total expected traffic control message responses
+  // uint16 msgtot
+  out_msg.msgtot = in_msg.msgtot;
+
+  // # msgnum INTEGER (0..65535), -- message index for each response out of total responses
+  // uint16 msgnum
+  out_msg.msgnum = in_msg.msgnum;
+
+  // # id Id128b, -- unique traffic control id
+  // uint8[16] id
+  out_msg.id = in_msg.id;
+
+  // # updated EpochMins
+  // time updated
+  out_msg.updated = in_msg.updated.toSec() / units::SEC_PER_MIN;
+
+  // # package [0] TrafficControlPackage OPTIONAL, -- related traffic control ids
+  // j2735_msgs/TrafficControlPackage package
+  // bool package_exists
+  out_msg.package_exists = in_msg.package_exists;
+  if(out_msg.package_exists)
+  {
+    out_msg.package = in_msg.package;
+  }
+
+  // # params [1] TrafficControlParams OPTIONAL
+  // cav_msgs/TrafficControlParams params
+  // bool params_exists
+  out_msg.params_exists = in_msg.params_exists;
+  if(out_msg.params_exists)
+  {
+    convert(in_msg.params, out_msg.params);
+  }
+
+  // # geometry [2] TrafficControlGeometry OPTIONAL
+  // cav_msgs/TrafficControlGeometry geometry
+  // bool geometry_exists
+  out_msg.geometry_exists = in_msg.geometry_exists;
+  if(out_msg.geometry_exists)
+  {
+    convert(in_msg.geometry, out_msg.geometry);
+  }
+
+  // # Bounds SEQUENCE (SIZE(1..63)) OF TrafficControlBounds
+  // cav_msgs/TrafficControlBounds[] bounds
+  for (auto in_bound : in_msg.bounds)
+  {
+    j2735_msgs::TrafficControlBounds out_bound;
+    convert(in_bound, out_bound);
+    out_msg.bounds.push_back(out_bound);
+  }
+}
+
+void convert(const cav_msgs::TrafficControlParams& in_msg, j2735_msgs::TrafficControlParams& out_msg)
+{
+  // j2735_msgs/TrafficControlVehClass[] vclasses
+  out_msg.vclasses = in_msg.vclasses;
+  
+  // # schedule TrafficControlSchedule
+  // cav_msgs/TrafficControlSchedule schedule
+  convert(in_msg.schedule, out_msg.schedule);
+
+  // # regulatory BOOLEAN
+  // bool regulatory
+  out_msg.regulatory = in_msg.regulatory;
+
+  // # detail TrafficControlDetail
+  // cav_msgs/TrafficControlDetail detail
+  convert(in_msg.detail, out_msg.detail);
+}
+
+void convert(const cav_msgs::TrafficControlSchedule& in_msg, j2735_msgs::TrafficControlSchedule& out_msg)
+{
+  out_msg.start = in_msg.start.toSec() / units::SEC_PER_MIN;
+
+  out_msg.end_exists = in_msg.end_exists;
+  if(out_msg.end_exists)
+  {
+    out_msg.end = in_msg.end.toSec() / units::SEC_PER_MIN;
+  }
+
+  out_msg.dow_exists = in_msg.dow_exists;
+  if(out_msg.dow_exists)
+  {
+    out_msg.dow = in_msg.dow;
+  }
+
+  out_msg.between_exists = in_msg.between_exists;
+  if(out_msg.between_exists)
+  {
+    for (auto in_between : in_msg.between)
+    {
+      j2735_msgs::DailySchedule out_between;
+      convert(in_between, out_between);
+      out_msg.between.push_back(out_between);
+    }
+  }
+
+  out_msg.repeat_exists = in_msg.repeat_exists;
+  if(out_msg.repeat_exists)
+  {
+    convert(in_msg.repeat, out_msg.repeat);
+  }
 }
 }  // namespace geofence_control
 }  // namespace j2735_convertor

--- a/carma-messenger-core/j2735_convertor/src/control_message_convertor.cpp
+++ b/carma-messenger-core/j2735_convertor/src/control_message_convertor.cpp
@@ -504,7 +504,7 @@ void convert(const cav_msgs::TrafficControlDetail& in_msg, j2735_msgs::TrafficCo
       out_msg.minhdwy = (uint16_t)(in_msg.minhdwy * units::DECA_M_PER_M);
       break;
     case cav_msgs::TrafficControlDetail::MAXVEHMASS_CHOICE : 
-      out_msg.maxvehmass = (int16_t)in_msg.maxvehmass;
+      out_msg.maxvehmass = (uint16_t)in_msg.maxvehmass;
       break;
     case cav_msgs::TrafficControlDetail::MAXVEHHEIGHT_CHOICE : 
       out_msg.maxvehheight = (uint8_t)(in_msg.maxvehheight * units::DECA_M_PER_M);

--- a/carma-messenger-core/j2735_convertor/src/control_message_convertor.cpp
+++ b/carma-messenger-core/j2735_convertor/src/control_message_convertor.cpp
@@ -104,12 +104,6 @@ void convert(const j2735_msgs::DailySchedule& in_msg, cav_msgs::DailySchedule& o
   out_msg.duration = ros::Duration(in_msg.duration * units::SEC_PER_MIN);
 }
 
-void convert(const j2735_msgs::OffsetPoint& in_msg, cav_msgs::OffsetPoint& out_msg)
-{
-  out_msg.deltax = (double)in_msg.deltax;
-  out_msg.deltay = (double)in_msg.deltay;
-}
-
 void convert(const j2735_msgs::PathNode& in_msg, cav_msgs::PathNode& out_msg)
 {
   out_msg.x = (double)in_msg.x / units::CM_PER_M;
@@ -133,18 +127,6 @@ void convert(const j2735_msgs::RepeatParams& in_msg, cav_msgs::RepeatParams& out
   out_msg.offset = ros::Duration(in_msg.offset * units::SEC_PER_MIN);
   out_msg.period = ros::Duration(in_msg.period * units::SEC_PER_MIN);
   out_msg.span = ros::Duration(in_msg.span * units::SEC_PER_MIN);
-}
-
-void convert(const j2735_msgs::TrafficControlBounds& in_msg, cav_msgs::TrafficControlBounds& out_msg)
-{
-  out_msg.oldest = ros::Time(in_msg.oldest * units::SEC_PER_MIN, 0);
-  out_msg.reflon = (double)in_msg.reflon / units::TENTH_MICRO_DEG_PER_DEG;
-  out_msg.reflat = (double)in_msg.reflat / units::TENTH_MICRO_DEG_PER_DEG;
-
-  for(int i = 0; i < 3; i++)
-  {
-    convert(in_msg.offsets[i], out_msg.offsets[i]);
-  }
 }
 
 void convert(const j2735_msgs::TrafficControlDetail& in_msg, cav_msgs::TrafficControlDetail& out_msg)
@@ -215,7 +197,9 @@ void convert(const j2735_msgs::TrafficControlDetail& in_msg, cav_msgs::TrafficCo
     case j2735_msgs::TrafficControlDetail::MINVEHOCC_CHOICE : 
       out_msg.minvehocc = in_msg.minvehocc;
       break;
-    
+    default : 
+      // Throw Error?
+      break;
   }
 }
 
@@ -248,6 +232,9 @@ void convert(const j2735_msgs::TrafficControlMessage& in_msg, cav_msgs::TrafficC
       break;
     case j2735_msgs::TrafficControlMessage::TCMV01 : 
       convert(in_msg.tcmV01, out_msg.tcmV01);
+      break;
+    default : 
+      // Throw Error?
       break;
   }
 }
@@ -303,15 +290,6 @@ void convert(const j2735_msgs::TrafficControlMessageV01& in_msg, cav_msgs::Traff
   if(out_msg.geometry_exists)
   {
     convert(in_msg.geometry, out_msg.geometry);
-  }
-
-  // # Bounds SEQUENCE (SIZE(1..63)) OF TrafficControlBounds
-  // cav_msgs/TrafficControlBounds[] bounds
-  for (auto in_bound : in_msg.bounds)
-  {
-    cav_msgs::TrafficControlBounds out_bound;
-    convert(in_bound, out_bound);
-    out_msg.bounds.push_back(out_bound);
   }
 }
 
@@ -450,12 +428,6 @@ void convert(const cav_msgs::DailySchedule& in_msg, j2735_msgs::DailySchedule& o
   out_msg.duration = in_msg.duration.toSec() / units::SEC_PER_MIN;
 }
 
-void convert(const cav_msgs::OffsetPoint& in_msg, j2735_msgs::OffsetPoint& out_msg)
-{
-  out_msg.deltax = (int16_t)in_msg.deltax;
-  out_msg.deltay = (int16_t)in_msg.deltay;
-}
-
 void convert(const cav_msgs::PathNode& in_msg, j2735_msgs::PathNode& out_msg)
 {
   out_msg.x = (int16_t)(in_msg.x * units::CM_PER_M);
@@ -479,18 +451,6 @@ void convert(const cav_msgs::RepeatParams& in_msg, j2735_msgs::RepeatParams& out
   out_msg.offset = in_msg.offset.toSec() / units::SEC_PER_MIN;
   out_msg.period = in_msg.period.toSec() / units::SEC_PER_MIN;
   out_msg.span = in_msg.span.toSec() / units::SEC_PER_MIN;
-}
-
-void convert(const cav_msgs::TrafficControlBounds& in_msg, j2735_msgs::TrafficControlBounds& out_msg)
-{
-  out_msg.oldest = in_msg.oldest.toSec() / units::SEC_PER_MIN;
-  out_msg.reflon = (int32_t)(in_msg.reflon * units::TENTH_MICRO_DEG_PER_DEG);
-  out_msg.reflat = (int32_t)(in_msg.reflat * units::TENTH_MICRO_DEG_PER_DEG);
-
-  for(int i = 0; i < 3; i++)
-  {
-    convert(in_msg.offsets[i], out_msg.offsets[i]);
-  }
 }
 
 void convert(const cav_msgs::TrafficControlDetail& in_msg, j2735_msgs::TrafficControlDetail& out_msg)
@@ -561,6 +521,9 @@ void convert(const cav_msgs::TrafficControlDetail& in_msg, j2735_msgs::TrafficCo
     case cav_msgs::TrafficControlDetail::MINVEHOCC_CHOICE : 
       out_msg.minvehocc = in_msg.minvehocc;
       break;
+    default : 
+      // Throw Error?
+      break;
   }
 }
 
@@ -593,6 +556,9 @@ void convert(const cav_msgs::TrafficControlMessage& in_msg, j2735_msgs::TrafficC
       break;
     case cav_msgs::TrafficControlMessage::TCMV01 : 
       convert(in_msg.tcmV01, out_msg.tcmV01);
+      break;
+    default : 
+      // Throw Error?
       break;
   }
 }
@@ -648,15 +614,6 @@ void convert(const cav_msgs::TrafficControlMessageV01& in_msg, j2735_msgs::Traff
   if(out_msg.geometry_exists)
   {
     convert(in_msg.geometry, out_msg.geometry);
-  }
-
-  // # Bounds SEQUENCE (SIZE(1..63)) OF TrafficControlBounds
-  // cav_msgs/TrafficControlBounds[] bounds
-  for (auto in_bound : in_msg.bounds)
-  {
-    j2735_msgs::TrafficControlBounds out_bound;
-    convert(in_bound, out_bound);
-    out_msg.bounds.push_back(out_bound);
   }
 }
 

--- a/carma-messenger-core/j2735_convertor/src/control_message_convertor.cpp
+++ b/carma-messenger-core/j2735_convertor/src/control_message_convertor.cpp
@@ -242,7 +242,7 @@ void convert(const j2735_msgs::TrafficControlMessage& in_msg, cav_msgs::TrafficC
 void convert(const j2735_msgs::TrafficControlMessageV01& in_msg, cav_msgs::TrafficControlMessageV01& out_msg)
 {
   // # reqid ::= Id64b
-  // uint8[8] reqid
+  // j2735_msgs/Id64b reqid
   out_msg.reqid = in_msg.reqid;
 
   // # reqseq ::= INTEGER (0..255)
@@ -258,7 +258,7 @@ void convert(const j2735_msgs::TrafficControlMessageV01& in_msg, cav_msgs::Traff
   out_msg.msgnum = in_msg.msgnum;
 
   // # id Id128b, -- unique traffic control id
-  // uint8[16] id
+  // j2735_msgs/Id128b id
   out_msg.id = in_msg.id;
 
   // # updated EpochMins
@@ -566,7 +566,7 @@ void convert(const cav_msgs::TrafficControlMessage& in_msg, j2735_msgs::TrafficC
 void convert(const cav_msgs::TrafficControlMessageV01& in_msg, j2735_msgs::TrafficControlMessageV01& out_msg)
 {
   // # reqid ::= Id64b
-  // uint8[8] reqid
+  // j2735_msgs/Id64b reqid
   out_msg.reqid = in_msg.reqid;
 
   // # reqseq ::= INTEGER (0..255)
@@ -582,7 +582,7 @@ void convert(const cav_msgs::TrafficControlMessageV01& in_msg, j2735_msgs::Traff
   out_msg.msgnum = in_msg.msgnum;
 
   // # id Id128b, -- unique traffic control id
-  // uint8[16] id
+  // j2735_msgs/Id128b id
   out_msg.id = in_msg.id;
 
   // # updated EpochMins

--- a/carma-messenger-core/j2735_convertor/test/control_message_test.cpp
+++ b/carma-messenger-core/j2735_convertor/test/control_message_test.cpp
@@ -29,6 +29,618 @@ using ::testing::ElementsAre;
 
 namespace j2735_convertor
 {
+  constexpr int NUM_NODES = 10;
+
+  /////////////////////////// J2735 TO CAV FUNCTIONS ///////////////////////////////
+
+  j2735_msgs::DailySchedule create_j2735_DailySchedule(bool optional = true)
+  {
+    j2735_msgs::DailySchedule in_msg;
+    in_msg.begin = 60; // min
+    in_msg.duration = 180; // min
+    return in_msg;
+  }
+
+  j2735_msgs::OffsetPoint create_j2735_OffsetPoint(bool optional = true)
+  {
+    j2735_msgs::OffsetPoint in_msg;
+    in_msg.deltax = 100; // min
+    in_msg.deltay = -1364; // min
+    return in_msg;
+  }
+
+  j2735_msgs::PathNode create_j2735_PathNode(bool optional = true)
+  {
+    j2735_msgs::PathNode in_msg;
+    in_msg.x = 20;
+    in_msg.y = 40;
+
+    in_msg.z_exists = optional;
+    in_msg.width_exists = optional;
+    if(optional)
+    {
+      in_msg.z = 50;
+      in_msg.width = 37;
+    }
+    return in_msg;
+  }
+
+  j2735_msgs::RepeatParams create_j2735_RepeatParams(bool optional = true)
+  {
+    j2735_msgs::RepeatParams in_msg;
+    in_msg.offset = 60; // min
+    in_msg.period = 360; // min
+    in_msg.span = 180; // min
+    return in_msg;
+  }
+
+  j2735_msgs::TrafficControlBounds create_j2735_TrafficControlBounds(bool optional = true)
+  {
+    j2735_msgs::TrafficControlBounds in_msg;
+    in_msg.oldest = 1000000;
+    in_msg.reflon = -400000000;
+    in_msg.reflat = 800000000;
+
+    for(int i = 0; i < 3; i++)
+    {
+      in_msg.offsets[i].deltax = 100;
+      in_msg.offsets[i].deltay = -1364;
+    }
+    return in_msg;
+  }
+
+  j2735_msgs::TrafficControlDetail create_j2735_TrafficControlDetail(bool optional = true)
+  {
+    j2735_msgs::TrafficControlDetail in_msg;
+    in_msg.choice = j2735_msgs::TrafficControlDetail::CLOSED_CHOICE;
+    in_msg.closed = j2735_msgs::TrafficControlDetail::TAPERLEFT;
+    return in_msg;
+  }
+
+  j2735_msgs::TrafficControlGeometry create_j2735_TrafficControlGeometry(bool optional = true)
+  {
+    j2735_msgs::TrafficControlGeometry in_msg;
+    in_msg.proj = "Project 1";
+    in_msg.datum = "Datum 1";
+    in_msg.reftime = 1000000;
+    in_msg.reflon = -400000000;
+    in_msg.reflat = 800000000;
+    in_msg.refelv = 50000;
+    in_msg.heading = 1800;
+
+    j2735_msgs::PathNode node;
+    for(int i = 0; i < NUM_NODES; i++)
+    {
+      node = create_j2735_PathNode();
+      in_msg.nodes.push_back(node);
+    }
+    return in_msg;
+  }
+
+  j2735_msgs::TrafficControlSchedule create_j2735_TrafficControlSchedule(bool optional = true)
+  {
+    j2735_msgs::TrafficControlSchedule in_msg;
+    in_msg.start = 1000000;
+    
+    in_msg.end_exists = optional;
+    in_msg.dow_exists = optional;
+    in_msg.between_exists = optional;
+    in_msg.repeat_exists = optional;
+    if(optional)
+    {
+      in_msg.end = 3000000;
+      in_msg.dow.dow = j2735_msgs::DayOfWeek::TUE;
+
+      j2735_msgs::DailySchedule ds;
+      for(int i = 0; i < NUM_NODES; i++)
+      {
+        ds = create_j2735_DailySchedule();
+        in_msg.between.push_back(ds);
+      }
+
+      in_msg.repeat = create_j2735_RepeatParams();
+    }
+    return in_msg;
+  }
+
+  j2735_msgs::TrafficControlParams create_j2735_TrafficControlParams(bool optional = true)
+  {
+    j2735_msgs::TrafficControlParams in_msg;
+
+    // # vclasses SEQUENCE (SIZE(1..255)) OF TrafficControlVehClass,
+    // j2735_msgs/TrafficControlVehClass[] vclasses
+    j2735_msgs::TrafficControlVehClass tcvc;
+    for(int i = 0; i < NUM_NODES; i++)
+    {
+      tcvc.vehicle_class = j2735_msgs::TrafficControlVehClass::BUS;
+      in_msg.vclasses.push_back(tcvc);
+    }
+    
+    // # schedule TrafficControlSchedule
+    // cav_msgs/TrafficControlSchedule schedule
+    in_msg.schedule = create_j2735_TrafficControlSchedule();
+
+    // # regulatory BOOLEAN
+    // bool regulatory
+    in_msg.regulatory = false;
+
+    // # detail TrafficControlDetail
+    // cav_msgs/TrafficControlDetail detail
+    in_msg.detail = create_j2735_TrafficControlDetail();
+    return in_msg;
+  }
+
+  j2735_msgs::TrafficControlMessageV01 create_j2735_TrafficControlMessageV01(bool optional = true)
+  {
+    j2735_msgs::TrafficControlMessageV01 in_msg;
+    // # reqid ::= Id64b
+    // uint8[8] reqid
+    in_msg.reqid = {0, 1, 2, 3, 4, 5, 6, 7};
+
+    // # reqseq ::= INTEGER (0..255)
+    // uint8 reqseq
+    in_msg.reqseq = 77;
+
+    // # msgtot INTEGER (0..65535), -- total expected traffic control message responses
+    // uint16 msgtot
+    in_msg.msgtot = 1;
+
+    // # msgnum INTEGER (0..65535), -- message index for each response out of total responses
+    // uint16 msgnum
+    in_msg.msgnum = 0;
+
+    // # id Id128b, -- unique traffic control id
+    // uint8[16] id
+    in_msg.id = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+
+    // # updated EpochMins
+    // time updated
+    in_msg.updated = 1000000;
+
+    // # package [0] TrafficControlPackage OPTIONAL, -- related traffic control ids
+    // j2735_msgs/TrafficControlPackage package
+    // bool package_exists
+    in_msg.package_exists = optional;
+    in_msg.package.label_exists = optional;
+
+    // # params [1] TrafficControlParams OPTIONAL
+    // cav_msgs/TrafficControlParams params
+    // bool params_exists
+    in_msg.params_exists = optional;
+
+    // # geometry [2] TrafficControlGeometry OPTIONAL
+    // cav_msgs/TrafficControlGeometry geometry
+    // bool geometry_exists
+    in_msg.geometry_exists = optional;
+
+    if(optional)
+    {
+      in_msg.package.label = "This Is A Label";
+      in_msg.package.tcids = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13};
+
+      in_msg.params = create_j2735_TrafficControlParams();
+      in_msg.geometry = create_j2735_TrafficControlGeometry();
+
+    }
+
+    j2735_msgs::TrafficControlBounds tcb;
+    for(int i = 0; i < NUM_NODES; i++)
+    {
+      tcb = create_j2735_TrafficControlBounds();
+      in_msg.bounds.push_back(tcb);
+    }
+
+    return in_msg;
+  }
+
+  j2735_msgs::TrafficControlMessage create_j2735_TrafficControlMessage(bool optional = true)
+  {
+    j2735_msgs::TrafficControlMessage in_msg;
+    in_msg.choice = j2735_msgs::TrafficControlMessage::TCMV01;
+    in_msg.tcmV01 = create_j2735_TrafficControlMessageV01();
+    return in_msg;
+  }
+
+  /////////////////////////// CAV TO J2735 FUNCTIONS //////////////////////////////
+
+  cav_msgs::DailySchedule create_cav_DailySchedule(bool optional = true)
+  {
+    cav_msgs::DailySchedule in_msg;
+    in_msg.begin = ros::Duration(36000);
+    in_msg.duration = ros::Duration(3600);
+    return in_msg;
+  }
+
+  cav_msgs::OffsetPoint create_cav_OffsetPoint(bool optional = true)
+  {
+    cav_msgs::OffsetPoint in_msg;
+    in_msg.deltax = 10.0;
+    in_msg.deltay = 20.0;
+    return in_msg;
+  }
+
+  cav_msgs::PathNode create_cav_PathNode(bool optional = true)
+  {
+    cav_msgs::PathNode in_msg;
+    in_msg.x = 20.0;
+    in_msg.y = 40.0;
+
+    in_msg.z_exists = optional;
+    in_msg.width_exists = optional;
+    if(optional)
+    {
+      in_msg.z = 50.0;
+      in_msg.width = 1.0;
+    }
+    return in_msg;
+  }
+
+  cav_msgs::RepeatParams create_cav_RepeatParams(bool optional = true)
+  {
+    cav_msgs::RepeatParams in_msg;
+    in_msg.offset = ros::Duration(3600);
+    in_msg.period = ros::Duration(6000);
+    in_msg.span = ros::Duration(1800);
+    return in_msg;
+  }
+
+  cav_msgs::TrafficControlBounds create_cav_TrafficControlBounds(bool optional = true)
+  {
+    cav_msgs::TrafficControlBounds in_msg;
+    in_msg.oldest = ros::Time(180000);
+    in_msg.reflon = -40.0;
+    in_msg.reflat = 80.0;
+
+    for(int i = 0; i < 3; i++)
+    {
+      in_msg.offsets[i] = create_cav_OffsetPoint();
+    }
+    return in_msg;
+  }
+
+  cav_msgs::TrafficControlDetail create_cav_TrafficControlDetail(bool optional = true)
+  {
+    cav_msgs::TrafficControlDetail in_msg;
+    in_msg.choice = cav_msgs::TrafficControlDetail::CLOSED_CHOICE;
+    in_msg.closed = cav_msgs::TrafficControlDetail::TAPERLEFT;
+    return in_msg;
+  }
+
+  cav_msgs::TrafficControlGeometry create_cav_TrafficControlGeometry(bool optional = true)
+  {
+    cav_msgs::TrafficControlGeometry in_msg;
+    in_msg.proj = "Project 1";
+    in_msg.datum = "Datum 1";
+    in_msg.reftime = ros::Time(180000);
+    in_msg.reflon = -40.0;
+    in_msg.reflat = 80.0;
+    in_msg.refelv = 500;
+    in_msg.heading = 180;
+
+    cav_msgs::PathNode node;
+    for(int i = 0; i < NUM_NODES; i++)
+    {
+      node = create_cav_PathNode();
+      in_msg.nodes.push_back(node);
+    }
+    return in_msg;
+  }
+
+  cav_msgs::TrafficControlSchedule create_cav_TrafficControlSchedule(bool optional = true)
+  {
+    cav_msgs::TrafficControlSchedule in_msg;
+    in_msg.start = ros::Time(180000);
+    
+    in_msg.end_exists = optional;
+    in_msg.dow_exists = optional;
+    in_msg.between_exists = optional;
+    in_msg.repeat_exists = optional;
+    if(optional)
+    {
+      in_msg.end = ros::Time(180000);
+      in_msg.dow.dow = j2735_msgs::DayOfWeek::TUE;
+
+      cav_msgs::DailySchedule ds;
+      for(int i = 0; i < NUM_NODES; i++)
+      {
+        ds = create_cav_DailySchedule();
+        in_msg.between.push_back(ds);
+      }
+
+      in_msg.repeat = create_cav_RepeatParams();
+    }
+    return in_msg;
+  }
+
+  cav_msgs::TrafficControlParams create_cav_TrafficControlParams(bool optional = true)
+  {
+    cav_msgs::TrafficControlParams in_msg;
+
+    // # vclasses SEQUENCE (SIZE(1..255)) OF TrafficControlVehClass,
+    // j2735_msgs/TrafficControlVehClass[] vclasses
+    j2735_msgs::TrafficControlVehClass tcvc;
+    for(int i = 0; i < NUM_NODES; i++)
+    {
+      tcvc.vehicle_class = j2735_msgs::TrafficControlVehClass::BUS;
+      in_msg.vclasses.push_back(tcvc);
+    }
+    
+    // # schedule TrafficControlSchedule
+    // cav_msgs/TrafficControlSchedule schedule
+    in_msg.schedule = create_cav_TrafficControlSchedule();
+
+    // # regulatory BOOLEAN
+    // bool regulatory
+    in_msg.regulatory = false;
+
+    // # detail TrafficControlDetail
+    // cav_msgs/TrafficControlDetail detail
+    in_msg.detail = create_cav_TrafficControlDetail();
+    return in_msg;
+  }
+
+  cav_msgs::TrafficControlMessageV01 create_cav_TrafficControlMessageV01(bool optional = true)
+  {
+    cav_msgs::TrafficControlMessageV01 in_msg;
+    // # reqid ::= Id64b
+    // uint8[8] reqid
+    in_msg.reqid = {0, 1, 2, 3, 4, 5, 6, 7};
+
+    // # reqseq ::= INTEGER (0..255)
+    // uint8 reqseq
+    in_msg.reqseq = 77;
+
+    // # msgtot INTEGER (0..65535), -- total expected traffic control message responses
+    // uint16 msgtot
+    in_msg.msgtot = 1;
+
+    // # msgnum INTEGER (0..65535), -- message index for each response out of total responses
+    // uint16 msgnum
+    in_msg.msgnum = 0;
+
+    // # id Id128b, -- unique traffic control id
+    // uint8[16] id
+    in_msg.id = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+
+    // # updated EpochMins
+    // time updated
+    in_msg.updated = ros::Time(180000);
+
+    // # package [0] TrafficControlPackage OPTIONAL, -- related traffic control ids
+    // j2735_msgs/TrafficControlPackage package
+    // bool package_exists
+    in_msg.package_exists = optional;
+
+    // # params [1] TrafficControlParams OPTIONAL
+    // cav_msgs/TrafficControlParams params
+    // bool params_exists
+    in_msg.params_exists = optional;
+
+    // # geometry [2] TrafficControlGeometry OPTIONAL
+    // cav_msgs/TrafficControlGeometry geometry
+    // bool geometry_exists
+    in_msg.geometry_exists = optional;
+
+    if(optional)
+    {
+      in_msg.package.label = "This Is A Label";
+      in_msg.package.tcids = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+
+      in_msg.params = create_cav_TrafficControlParams();
+      in_msg.geometry = create_cav_TrafficControlGeometry();
+
+    }
+
+    cav_msgs::TrafficControlBounds tcb;
+    for(int i = 0; i < NUM_NODES; i++)
+    {
+      tcb = create_cav_TrafficControlBounds();
+      in_msg.bounds.push_back(tcb);
+    }
+
+    return in_msg;
+  }
+
+  cav_msgs::TrafficControlMessage create_cav_TrafficControlMessage(bool optional = true)
+  {
+    cav_msgs::TrafficControlMessage in_msg;
+    in_msg.choice = cav_msgs::TrafficControlMessage::TCMV01;
+    in_msg.tcmV01 = create_cav_TrafficControlMessageV01();
+    return in_msg;
+  }
+
+  ////////////////////////////////// TEST FUNCTIONS ////////////////////////////////
+
+  void test_DailySchedule(
+    j2735_msgs::DailySchedule in_msg, 
+    cav_msgs::DailySchedule out_msg)
+  {
+    ASSERT_EQ(out_msg.begin.sec, in_msg.begin * units::SEC_PER_MIN);
+    ASSERT_EQ(out_msg.begin.nsec, 0);
+    ASSERT_EQ(out_msg.duration.sec, in_msg.duration * units::SEC_PER_MIN);
+    ASSERT_EQ(out_msg.duration.nsec, 0);
+  }
+
+  void test_OffsetPoint(
+    j2735_msgs::OffsetPoint in_msg, 
+    cav_msgs::OffsetPoint out_msg)
+  {
+    ASSERT_NEAR(out_msg.deltax, out_msg.deltax, 0.000001);
+    ASSERT_NEAR(out_msg.deltay, out_msg.deltay, 0.000001);
+  }
+
+  void test_PathNode(
+    j2735_msgs::PathNode in_msg, 
+    cav_msgs::PathNode out_msg)
+  {
+    ASSERT_NEAR((double)in_msg.x / units::CM_PER_M, out_msg.x, 0.000001);
+    ASSERT_NEAR((double)in_msg.y / units::CM_PER_M, out_msg.y, 0.000001);
+    ASSERT_EQ(in_msg.z_exists, out_msg.z_exists);
+    ASSERT_EQ(in_msg.width_exists, out_msg.width_exists);
+
+    if(in_msg.z_exists)
+    {
+      ASSERT_NEAR((double)in_msg.z / units::CM_PER_M, out_msg.z, 0.000001);
+    }
+    if(in_msg.width_exists)
+    {
+      ASSERT_NEAR((double)in_msg.width / units::CM_PER_M, out_msg.width, 0.000001);
+    }
+  }
+
+  void test_RepeatParams(
+    j2735_msgs::RepeatParams in_msg, 
+    cav_msgs::RepeatParams out_msg)
+  {
+    ASSERT_EQ(out_msg.offset.sec, in_msg.offset * units::SEC_PER_MIN);
+    ASSERT_EQ(out_msg.offset.nsec, 0);
+    ASSERT_EQ(out_msg.period.sec, in_msg.period * units::SEC_PER_MIN);
+    ASSERT_EQ(out_msg.period.nsec, 0);
+    ASSERT_EQ(out_msg.span.sec, in_msg.span * units::SEC_PER_MIN);
+    ASSERT_EQ(out_msg.span.nsec, 0);
+  }
+
+  void test_TrafficControlBounds(
+    j2735_msgs::TrafficControlBounds in_msg, 
+    cav_msgs::TrafficControlBounds out_msg)
+  {
+    ASSERT_EQ(out_msg.oldest.sec, in_msg.oldest * units::SEC_PER_MIN);
+    ASSERT_EQ(out_msg.oldest.nsec, 0.);
+    ASSERT_NEAR(in_msg.reflon, out_msg.reflon * units::TENTH_MICRO_DEG_PER_DEG, 0.000001);
+    ASSERT_NEAR(in_msg.reflat, out_msg.reflat * units::TENTH_MICRO_DEG_PER_DEG, 0.000001);
+
+    for(int i = 0; i < 3; i++)
+    {
+      auto in_offset = in_msg.offsets[i];
+      auto out_offset = out_msg.offsets[i];
+      ASSERT_NEAR(in_offset.deltax, out_offset.deltax, 0.000001);
+      ASSERT_NEAR(in_offset.deltay, out_offset.deltay, 0.000001);
+    }
+  }
+
+  void test_TrafficControlDetail(
+    j2735_msgs::TrafficControlDetail in_msg, 
+    cav_msgs::TrafficControlDetail out_msg)
+  {
+    ASSERT_EQ(out_msg.choice, in_msg.choice);
+    ASSERT_EQ(out_msg.closed, in_msg.closed);
+  }
+
+  void test_TrafficControlGeometry(
+    j2735_msgs::TrafficControlGeometry in_msg, 
+    cav_msgs::TrafficControlGeometry out_msg)
+  {
+    ASSERT_EQ(out_msg.proj, in_msg.proj);
+    ASSERT_EQ(out_msg.datum, in_msg.datum);
+    ASSERT_EQ(out_msg.reftime.sec, in_msg.reftime * units::SEC_PER_MIN);
+    ASSERT_EQ(out_msg.reftime.nsec, 0.);
+    ASSERT_NEAR(in_msg.reflon, out_msg.reflon * units::TENTH_MICRO_DEG_PER_DEG, 0.000001);
+    ASSERT_NEAR(in_msg.reflat, out_msg.reflat * units::TENTH_MICRO_DEG_PER_DEG, 0.000001);
+    ASSERT_NEAR(in_msg.refelv, out_msg.refelv * units::DECA_M_PER_M, 0.000001);
+    ASSERT_NEAR(in_msg.heading, out_msg.heading * units::DECA_S_PER_S, 0.000001);
+
+    for(int i = 0; i < NUM_NODES; i++)
+    {
+      test_PathNode(in_msg.nodes[i], out_msg.nodes[i]);
+    }
+  }
+
+  void test_TrafficControlSchedule(
+    j2735_msgs::TrafficControlSchedule in_msg, 
+    cav_msgs::TrafficControlSchedule out_msg)
+  {
+    ASSERT_EQ(out_msg.start.sec, in_msg.start * units::SEC_PER_MIN);
+    ASSERT_EQ(out_msg.start.nsec, 0);
+
+    ASSERT_EQ(out_msg.end_exists, in_msg.end_exists);
+    if(in_msg.end_exists)
+    {
+      ASSERT_EQ(out_msg.end.sec, in_msg.end * units::SEC_PER_MIN);
+      ASSERT_EQ(out_msg.end.nsec, 0);
+    }
+    
+    ASSERT_EQ(out_msg.dow_exists, in_msg.dow_exists);
+    if(in_msg.dow_exists)
+    {
+      ASSERT_EQ(out_msg.dow.dow, in_msg.dow.dow);
+    }
+
+    ASSERT_EQ(out_msg.between_exists, in_msg.between_exists);
+    if(in_msg.between_exists)
+    {
+      for(int i = 0; i < NUM_NODES; i++)
+      {
+        test_DailySchedule(in_msg.between[i], out_msg.between[i]);
+      }
+    }
+    
+    ASSERT_EQ(out_msg.repeat_exists, in_msg.repeat_exists);
+    if(in_msg.repeat_exists)
+    {
+      test_RepeatParams(in_msg.repeat, out_msg.repeat);
+    }
+  }
+  
+  void test_TrafficControlParams(
+    j2735_msgs::TrafficControlParams in_msg, 
+    cav_msgs::TrafficControlParams out_msg)
+  {
+    for(int i = 0; i < NUM_NODES; i++)
+    {
+      ASSERT_EQ(out_msg.vclasses[i].vehicle_class, in_msg.vclasses[i].vehicle_class);
+    }
+
+    test_TrafficControlSchedule(in_msg.schedule, out_msg.schedule);
+
+    ASSERT_EQ(out_msg.regulatory, in_msg.regulatory);
+
+  test_TrafficControlDetail(in_msg.detail, out_msg.detail);
+  }
+
+  void test_TrafficControlMessageV01(
+    j2735_msgs::TrafficControlMessageV01 in_msg, 
+    cav_msgs::TrafficControlMessageV01 out_msg)
+  {
+    ASSERT_EQ(in_msg.reqid, out_msg.reqid);
+    ASSERT_EQ(in_msg.reqseq, out_msg.reqseq);
+    ASSERT_EQ(in_msg.msgtot, out_msg.msgtot);
+    ASSERT_EQ(in_msg.msgnum, out_msg.msgnum);
+    ASSERT_EQ(in_msg.id, out_msg.id);
+    ASSERT_EQ(out_msg.updated.sec, in_msg.updated * units::SEC_PER_MIN);
+    ASSERT_EQ(out_msg.updated.nsec, 0);
+
+    ASSERT_EQ(in_msg.package_exists, out_msg.package_exists);
+    if(in_msg.package_exists)
+    {
+      ASSERT_EQ(in_msg.package.label, out_msg.package.label);
+      ASSERT_EQ(in_msg.package.tcids, out_msg.package.tcids);
+    }
+
+    ASSERT_EQ(in_msg.params_exists, out_msg.params_exists);
+    if(in_msg.params_exists)
+    {
+      test_TrafficControlParams(in_msg.params, out_msg.params);
+    }
+
+    ASSERT_EQ(in_msg.geometry_exists, out_msg.geometry_exists);
+    if(in_msg.geometry_exists)
+    {
+      test_TrafficControlGeometry(in_msg.geometry, out_msg.geometry);
+    }
+    
+    for(int i = 0; i < NUM_NODES; i++)
+    {
+      test_TrafficControlBounds(in_msg.bounds[i], out_msg.bounds[i]);
+    }
+  }
+  
+  void test_TTrafficControlMessage(
+    j2735_msgs::TrafficControlMessage in_msg, 
+    cav_msgs::TrafficControlMessage out_msg)
+  {
+    ASSERT_EQ(out_msg.choice, in_msg.choice);
+    test_TrafficControlMessageV01(in_msg.tcmV01, out_msg.tcmV01);
+  }
 
 TEST(ControlMessage, convertControlMessageToCAV)
 {
@@ -98,12 +710,11 @@ TEST(ControlMessage, convertControlMessageToCAV)
   ASSERT_NEAR(out_msg.altitude, 500-428, 0.00001); // Need to subtract 428 to address offset
   ASSERT_NEAR(out_msg.heading, 30.0, 0.000001);
 
-  constexpr double CM_TO_M = 0.01; 
   ASSERT_EQ(p.z_exists, out_msg.points[0].z_exists);
-  ASSERT_NEAR((double)p.x * CM_TO_M, out_msg.points[0].x, 0.000001);
-  ASSERT_NEAR((double)p.y * CM_TO_M, out_msg.points[0].y, 0.000001);
-  ASSERT_NEAR((double)p.z * CM_TO_M, out_msg.points[0].z, 0.000001);
-  ASSERT_NEAR((double)p.width * CM_TO_M, out_msg.points[0].width, 0.000001);
+  ASSERT_NEAR((double)p.x / units::CM_PER_M, out_msg.points[0].x, 0.000001);
+  ASSERT_NEAR((double)p.y / units::CM_PER_M, out_msg.points[0].y, 0.000001);
+  ASSERT_NEAR((double)p.z / units::CM_PER_M, out_msg.points[0].z, 0.000001);
+  ASSERT_NEAR((double)p.width / units::CM_PER_M, out_msg.points[0].width, 0.000001);
 }
 
 TEST(ControlMessage, convertScheduleToCAV)
@@ -200,7 +811,6 @@ TEST(ControlMessage, convertScheduleParamsToCAV)
 
 TEST(ControlMessage, convertPointToCAV)
 {
-  constexpr double CM_TO_M = 0.01; 
   // Test with z
   j2735_msgs::Point input;
   input.x = 20;
@@ -212,25 +822,296 @@ TEST(ControlMessage, convertPointToCAV)
   cav_msgs::Point output;
   j2735_convertor::geofence_control::convert(input, output);
   ASSERT_EQ(input.z_exists, output.z_exists);
-  ASSERT_NEAR((double)input.x * CM_TO_M, output.x, 0.000001);
-  ASSERT_NEAR((double)input.y * CM_TO_M, output.y, 0.000001);
-  ASSERT_NEAR((double)input.z * CM_TO_M, output.z, 0.000001);
-  ASSERT_NEAR((double)input.width * CM_TO_M, output.width, 0.000001);
+  ASSERT_NEAR((double)input.x / units::CM_PER_M, output.x, 0.000001);
+  ASSERT_NEAR((double)input.y / units::CM_PER_M, output.y, 0.000001);
+  ASSERT_NEAR((double)input.z / units::CM_PER_M, output.z, 0.000001);
+  ASSERT_NEAR((double)input.width / units::CM_PER_M, output.width, 0.000001);
 
   // Test without z
   input.x = 22;
   input.y = 43;
   input.z = 0;
   input.z_exists = false;
-  input.width = 370;
+  input.width = 37;
 
   j2735_convertor::geofence_control::convert(input, output);
   ASSERT_EQ(input.z_exists, output.z_exists);
-  ASSERT_NEAR((double)input.x * CM_TO_M, output.x, 0.000001);
-  ASSERT_NEAR((double)input.y * CM_TO_M, output.y, 0.000001);
-  ASSERT_NEAR((double)input.z * CM_TO_M, output.z, 0.000001);
-  ASSERT_NEAR((double)input.width * CM_TO_M, output.width, 0.000001);
+  ASSERT_NEAR((double)input.x / units::CM_PER_M, output.x, 0.000001);
+  ASSERT_NEAR((double)input.y / units::CM_PER_M, output.y, 0.000001);
+  ASSERT_NEAR((double)input.z / units::CM_PER_M, output.z, 0.000001);
+  ASSERT_NEAR((double)input.width / units::CM_PER_M, output.width, 0.000001);
 }
+
+TEST(ControlMessage, convertDailyScheduleToCAV)
+{
+  // Create variables
+  j2735_msgs::DailySchedule in_msg;
+  cav_msgs::DailySchedule out_msg;
+
+  // Test
+  in_msg = create_j2735_DailySchedule();
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  test_DailySchedule(in_msg, out_msg);
+}
+
+TEST(ControlMessage, convertOffsetPointToCAV)
+{
+  // Create variables
+  j2735_msgs::OffsetPoint in_msg;
+  cav_msgs::OffsetPoint out_msg;
+
+  // Test
+  in_msg = create_j2735_OffsetPoint();
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  test_OffsetPoint(in_msg, out_msg);
+}
+
+TEST(ControlMessage, convertPathNodeToCAV)
+{
+  // Create variables
+  j2735_msgs::PathNode in_msg;
+  cav_msgs::PathNode out_msg;
+
+  // Test with all optional elements
+  in_msg = create_j2735_PathNode();
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  test_PathNode(in_msg, out_msg);
+
+  // Test without optional elements
+  in_msg = create_j2735_PathNode(false);
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  test_PathNode(in_msg, out_msg);
+}
+
+TEST(ControlMessage, convertRepeatParamsToCAV)
+{
+  // Create variables
+  j2735_msgs::RepeatParams in_msg;
+  cav_msgs::RepeatParams out_msg;
+
+  // Test
+  in_msg = create_j2735_RepeatParams(false);
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  test_RepeatParams(in_msg, out_msg);
+}
+
+TEST(ControlMessage, convertTrafficControlBoundsToCAV)
+{
+  // Create variables
+  j2735_msgs::TrafficControlBounds in_msg;
+  cav_msgs::TrafficControlBounds out_msg;
+
+  // Test
+  in_msg = create_j2735_TrafficControlBounds();
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  test_TrafficControlBounds(in_msg, out_msg);
+}
+
+  
+
+TEST(ControlMessage, convertTrafficControlDetailToCAV)
+{
+  j2735_msgs::TrafficControlDetail in_msg;
+  cav_msgs::TrafficControlDetail out_msg;
+
+  // SIGNAL Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::SIGNAL_CHOICE;
+  in_msg.signal = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_EQ(in_msg.signal, out_msg.signal);
+
+  // CLOSED Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::CLOSED_CHOICE;
+  in_msg.closed = j2735_msgs::TrafficControlDetail::TAPERLEFT;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_EQ(out_msg.closed, in_msg.closed);
+
+  // CHAINS Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::CHAINS_CHOICE;
+  in_msg.chains = j2735_msgs::TrafficControlDetail::NO;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_EQ(out_msg.chains, in_msg.chains);
+
+  // DIRECTION Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::DIRECTION_CHOICE;
+  in_msg.direction = j2735_msgs::TrafficControlDetail::FORWARD;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_EQ(out_msg.direction, in_msg.direction);
+
+  // LATAFFINITY Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::LATAFFINITY_CHOICE;
+  in_msg.lataffinity = j2735_msgs::TrafficControlDetail::LEFT;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_EQ(out_msg.lataffinity, in_msg.lataffinity);
+
+  // LATPERM Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::LATPERM_CHOICE;
+  for(int i = 0; i < 2; i++)
+  {
+    in_msg.latperm[i] = j2735_msgs::TrafficControlDetail::EMERGENCYONLY;
+  }
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  for(int i = 0; i < 2; i++)
+  {
+    ASSERT_EQ(in_msg.latperm[i], out_msg.latperm[i]);
+  }
+
+  // PARKING Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::PARKING_CHOICE;
+  in_msg.parking = j2735_msgs::TrafficControlDetail::PARALLEL;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_EQ(out_msg.parking, in_msg.parking);
+
+  // MINSPEED Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::MINSPEED_CHOICE;
+  in_msg.minspeed = 100;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_NEAR(in_msg.minspeed, out_msg.minspeed * units::DECA_MPS_PER_MPS, 0.000001);
+
+  // MAXSPEED Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::MAXSPEED_CHOICE;
+  in_msg.maxspeed = 100;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_NEAR(in_msg.maxspeed, out_msg.maxspeed * units::DECA_MPS_PER_MPS, 0.000001);
+
+  // MINHDWY Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::MINHDWY_CHOICE;
+  in_msg.minhdwy = 100;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_NEAR(in_msg.minhdwy, out_msg.minhdwy * units::DECA_M_PER_M, 0.000001);
+
+  // MAXVEHMASS Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::MAXVEHMASS_CHOICE;
+  in_msg.maxvehmass = 100;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_NEAR(in_msg.maxvehmass, out_msg.maxvehmass, 0.000001);
+  
+  // MAXVEHHEIGHT Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::MAXVEHHEIGHT_CHOICE;
+  in_msg.maxvehheight = 100;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_NEAR(in_msg.maxvehheight, out_msg.maxvehheight * units::DECA_M_PER_M, 0.000001);
+  
+  // MAXVEHWIDTH Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::MAXVEHWIDTH_CHOICE;
+  in_msg.maxvehwidth = 100;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_NEAR(in_msg.maxvehwidth, out_msg.maxvehwidth * units::DECA_M_PER_M, 0.000001);
+  
+  // MAXVEHLENGTH Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::MAXVEHLENGTH_CHOICE;
+  in_msg.maxvehlength = 100;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_NEAR(in_msg.maxvehlength, out_msg.maxvehlength * units::DECA_M_PER_M, 0.000001);
+  
+  // MAXVEHAXLES Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::MAXVEHAXLES_CHOICE;
+  in_msg.maxvehaxles = 100;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_NEAR(in_msg.maxvehaxles, out_msg.maxvehaxles, 0.000001);
+  
+  // MINVEHOCC Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::MINVEHOCC_CHOICE;
+  in_msg.minvehocc = 100;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_NEAR(in_msg.minvehocc, out_msg.minvehocc, 0.000001);
+  
+}
+
+TEST(ControlMessage, convertTrafficControlGeometryToCAV)
+{
+  // Create variables
+  j2735_msgs::TrafficControlGeometry in_msg;
+  cav_msgs::TrafficControlGeometry out_msg;
+
+  // Test
+  in_msg = create_j2735_TrafficControlGeometry();
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  test_TrafficControlGeometry(in_msg, out_msg);
+}
+
+TEST(ControlMessage, convertTrafficControlMessageToCAV)
+{
+  // Create variables
+  j2735_msgs::TrafficControlMessage in_msg;
+  cav_msgs::TrafficControlMessage out_msg;
+
+  // Test RESERVED
+  in_msg.choice = j2735_msgs::TrafficControlMessage::RESERVED;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+
+  // Test TCMV01
+  in_msg.choice = j2735_msgs::TrafficControlMessage::TCMV01;
+  in_msg.tcmV01 = create_j2735_TrafficControlMessageV01();
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  test_TrafficControlMessageV01(in_msg.tcmV01, out_msg.tcmV01);
+}
+
+TEST(ControlMessage, convertTrafficControlMessageV01ToCAV)
+{
+  // Create variables
+  j2735_msgs::TrafficControlMessageV01 in_msg;
+  cav_msgs::TrafficControlMessageV01 out_msg;
+
+  // Test with all optional elements
+  in_msg = create_j2735_TrafficControlMessageV01();
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  test_TrafficControlMessageV01(in_msg, out_msg);
+
+  // Test without optional elements
+  in_msg = create_j2735_TrafficControlMessageV01(false);
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  test_TrafficControlMessageV01(in_msg, out_msg);
+}
+
+TEST(ControlMessage, convertTrafficControlParamsToCAV)
+{
+  // Create variables
+  j2735_msgs::TrafficControlParams in_msg;
+  cav_msgs::TrafficControlParams out_msg;
+
+  // Test
+  in_msg = create_j2735_TrafficControlParams();
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  test_TrafficControlParams(in_msg, out_msg);
+}
+
+TEST(ControlMessage, convertTrafficControlScheduleToCAV)
+{
+  // Create variables
+  j2735_msgs::TrafficControlSchedule in_msg;
+  cav_msgs::TrafficControlSchedule out_msg;
+
+  // Test with all optional elements
+  in_msg = create_j2735_TrafficControlSchedule();
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  test_TrafficControlSchedule(in_msg, out_msg);
+
+  // Test without optional elements
+  in_msg = create_j2735_TrafficControlSchedule(false);
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  test_TrafficControlSchedule(in_msg, out_msg);
+}
+
+////////////// Convert CAV messages to J2735 /////////////////////////
 
 TEST(ControlMessage, convertControlMessageToj2735)
 {
@@ -421,4 +1302,281 @@ TEST(ControlMessage, convertPointToj2735)
   ASSERT_EQ((int)(input.width * M_TO_CM), output.width);
 }
 
+TEST(ControlMessage, convertDailyScheduleToJ2735)
+{
+  // Create variables
+  cav_msgs::DailySchedule in_msg;
+  j2735_msgs::DailySchedule out_msg;
+
+  // Test
+  in_msg = create_cav_DailySchedule();
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  test_DailySchedule(out_msg, in_msg);
+}
+
+TEST(ControlMessage, convertOffsetPointToJ2735)
+{
+  // Create variables
+  cav_msgs::OffsetPoint in_msg;
+  j2735_msgs::OffsetPoint out_msg;
+
+  // Test
+  in_msg = create_cav_OffsetPoint();
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  test_OffsetPoint(out_msg, in_msg);
+}
+
+TEST(ControlMessage, convertPathNodeToJ2735)
+{
+  // Create variables
+  cav_msgs::PathNode in_msg;
+  j2735_msgs::PathNode out_msg;
+
+  // Test with all optional elements
+  in_msg = create_cav_PathNode();
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  test_PathNode(out_msg, in_msg);
+
+  // Test without optional elements
+  in_msg = create_cav_PathNode(false);
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  test_PathNode(out_msg, in_msg);
+}
+
+TEST(ControlMessage, convertRepeatParamsToJ2735)
+{
+  // Create variables
+  cav_msgs::RepeatParams in_msg;
+  j2735_msgs::RepeatParams out_msg;
+
+  // Test
+  in_msg = create_cav_RepeatParams(false);
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  test_RepeatParams(out_msg, in_msg);
+}
+
+TEST(ControlMessage, convertTrafficControlBoundsToJ2735)
+{
+  // Create variables
+  cav_msgs::TrafficControlBounds in_msg;
+  j2735_msgs::TrafficControlBounds out_msg;
+
+  // Test
+  in_msg = create_cav_TrafficControlBounds();
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  test_TrafficControlBounds(out_msg, in_msg);
+}
+
+TEST(ControlMessage, convertTrafficControlDetailToJ2735)
+{
+  cav_msgs::TrafficControlDetail in_msg;
+  j2735_msgs::TrafficControlDetail out_msg;
+
+  // // SIGNAL Test
+  // in_msg.choice = cav_msgs::TrafficControlDetail::SIGNAL_CHOICE;
+
+  // int sig;
+  // for(int i = 0; i < NUM_NODES; i++)
+  // {
+  //   sig = i;
+  //   in_msg.signal.push_back(sig);
+  // }
+
+  // j2735_convertor::geofence_control::convert(in_msg, out_msg);
+
+  // ASSERT_EQ(out_msg.choice, in_msg.choice);
+  // for(int i = 0; i < NUM_NODES; i++)
+  // {
+  //   ASSERT_EQ(in_msg.signal[i], out_msg.signal[i]);
+  // }
+
+  // CLOSED Test
+  in_msg.choice = cav_msgs::TrafficControlDetail::CLOSED_CHOICE;
+  in_msg.closed = cav_msgs::TrafficControlDetail::TAPERLEFT;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_EQ(out_msg.closed, in_msg.closed);
+
+  // CHAINS Test
+  in_msg.choice = cav_msgs::TrafficControlDetail::CHAINS_CHOICE;
+  in_msg.chains = cav_msgs::TrafficControlDetail::NO;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_EQ(out_msg.chains, in_msg.chains);
+
+  // DIRECTION Test
+  in_msg.choice = cav_msgs::TrafficControlDetail::DIRECTION_CHOICE;
+  in_msg.direction = cav_msgs::TrafficControlDetail::FORWARD;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_EQ(out_msg.direction, in_msg.direction);
+
+  // LATAFFINITY Test
+  in_msg.choice = cav_msgs::TrafficControlDetail::LATAFFINITY_CHOICE;
+  in_msg.lataffinity = cav_msgs::TrafficControlDetail::LEFT;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_EQ(out_msg.lataffinity, in_msg.lataffinity);
+
+  // LATPERM Test
+  in_msg.choice = cav_msgs::TrafficControlDetail::LATPERM_CHOICE;
+  for(int i = 0; i < 2; i++)
+  {
+    in_msg.latperm[i] = cav_msgs::TrafficControlDetail::EMERGENCYONLY;
+  }
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  for(int i = 0; i < 2; i++)
+  {
+    ASSERT_EQ(in_msg.latperm[i], out_msg.latperm[i]);
+  }
+
+  // PARKING Test
+  in_msg.choice = cav_msgs::TrafficControlDetail::PARKING_CHOICE;
+  in_msg.parking = cav_msgs::TrafficControlDetail::PARALLEL;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_EQ(out_msg.parking, in_msg.parking);
+
+  // MINSPEED Test
+  in_msg.choice = cav_msgs::TrafficControlDetail::MINSPEED_CHOICE;
+  in_msg.minspeed = 10;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_NEAR(in_msg.minspeed, (float)out_msg.minspeed / units::DECA_MPS_PER_MPS, 0.000001);
+
+  // MAXSPEED Test
+  in_msg.choice = cav_msgs::TrafficControlDetail::MAXSPEED_CHOICE;
+  in_msg.maxspeed = 10;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_NEAR(in_msg.maxspeed, (float)out_msg.maxspeed / units::DECA_MPS_PER_MPS, 0.000001);
+
+  // MINHDWY Test
+  in_msg.choice = cav_msgs::TrafficControlDetail::MINHDWY_CHOICE;
+  in_msg.minhdwy = 10;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_NEAR(in_msg.minhdwy, (float)out_msg.minhdwy / units::DECA_M_PER_M, 0.000001);
+
+  // MAXVEHMASS Test
+  in_msg.choice = cav_msgs::TrafficControlDetail::MAXVEHMASS_CHOICE;
+  in_msg.maxvehmass = 10;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_NEAR(in_msg.maxvehmass, out_msg.maxvehmass, 0.000001);
+  
+  // MAXVEHHEIGHT Test
+  in_msg.choice = cav_msgs::TrafficControlDetail::MAXVEHHEIGHT_CHOICE;
+  in_msg.maxvehheight = 10;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_NEAR(in_msg.maxvehheight, (float)out_msg.maxvehheight / units::DECA_M_PER_M, 0.000001);
+  
+  // MAXVEHWIDTH Test
+  in_msg.choice = cav_msgs::TrafficControlDetail::MAXVEHWIDTH_CHOICE;
+  in_msg.maxvehwidth = 10;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_NEAR(in_msg.maxvehwidth, (float)out_msg.maxvehwidth / units::DECA_M_PER_M, 0.000001);
+  
+  // MAXVEHLENGTH Test
+  in_msg.choice = cav_msgs::TrafficControlDetail::MAXVEHLENGTH_CHOICE;
+  in_msg.maxvehlength = 10;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_NEAR(in_msg.maxvehlength, (float)out_msg.maxvehlength / units::DECA_M_PER_M, 0.000001);
+  
+  // MAXVEHAXLES Test
+  in_msg.choice = cav_msgs::TrafficControlDetail::MAXVEHAXLES_CHOICE;
+  in_msg.maxvehaxles = 10;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_NEAR(in_msg.maxvehaxles, out_msg.maxvehaxles, 0.000001);
+  
+  // MINVEHOCC Test
+  in_msg.choice = cav_msgs::TrafficControlDetail::MINVEHOCC_CHOICE;
+  in_msg.minvehocc = 10;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_NEAR(in_msg.minvehocc, out_msg.minvehocc, 0.000001);
+  
+}
+
+TEST(ControlMessage, convertTrafficControlGeometryToJ2735)
+{
+  // Create variables
+  cav_msgs::TrafficControlGeometry in_msg;
+  j2735_msgs::TrafficControlGeometry out_msg;
+
+  // Test
+  in_msg = create_cav_TrafficControlGeometry();
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  test_TrafficControlGeometry(out_msg, in_msg);
+}
+
+TEST(ControlMessage, convertTrafficControlMessageToJ2735)
+{
+  // Create variables
+  cav_msgs::TrafficControlMessage in_msg;
+  j2735_msgs::TrafficControlMessage out_msg;
+
+  // Test RESERVED
+  in_msg.choice = cav_msgs::TrafficControlMessage::RESERVED;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+
+  // Test TCMV01
+  in_msg.choice = cav_msgs::TrafficControlMessage::TCMV01;
+  in_msg.tcmV01 = create_cav_TrafficControlMessageV01();
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  test_TrafficControlMessageV01(out_msg.tcmV01, in_msg.tcmV01);
+}
+
+TEST(ControlMessage, convertTrafficControlMessageV01ToJ2735)
+{
+  // Create variables
+  cav_msgs::TrafficControlMessageV01 in_msg;
+  j2735_msgs::TrafficControlMessageV01 out_msg;
+
+  // Test with all optional elements
+  in_msg = create_cav_TrafficControlMessageV01();
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  test_TrafficControlMessageV01(out_msg, in_msg);
+
+  // Test without optional elements
+  in_msg = create_cav_TrafficControlMessageV01(false);
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  test_TrafficControlMessageV01(out_msg, in_msg);
+}
+
+TEST(ControlMessage, convertTrafficControlParamsToJ2735)
+{
+  // Create variables
+  cav_msgs::TrafficControlParams in_msg;
+  j2735_msgs::TrafficControlParams out_msg;
+
+  // Test
+  in_msg = create_cav_TrafficControlParams();
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  test_TrafficControlParams(out_msg, in_msg);
+}
+
+TEST(ControlMessage, convertTrafficControlScheduleToJ2735)
+{
+  // Create variables
+  cav_msgs::TrafficControlSchedule in_msg;
+  j2735_msgs::TrafficControlSchedule out_msg;
+
+  // Test with all optional elements
+  in_msg = create_cav_TrafficControlSchedule();
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  test_TrafficControlSchedule(out_msg, in_msg);
+
+  // Test without optional elements
+  in_msg = create_cav_TrafficControlSchedule(false);
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  test_TrafficControlSchedule(out_msg, in_msg);
+}
 }  // namespace j2735_convertor

--- a/carma-messenger-core/j2735_convertor/test/control_message_test.cpp
+++ b/carma-messenger-core/j2735_convertor/test/control_message_test.cpp
@@ -41,14 +41,6 @@ namespace j2735_convertor
     return in_msg;
   }
 
-  j2735_msgs::OffsetPoint create_j2735_OffsetPoint(bool optional = true)
-  {
-    j2735_msgs::OffsetPoint in_msg;
-    in_msg.deltax = 100; // min
-    in_msg.deltay = -1364; // min
-    return in_msg;
-  }
-
   j2735_msgs::PathNode create_j2735_PathNode(bool optional = true)
   {
     j2735_msgs::PathNode in_msg;
@@ -71,21 +63,6 @@ namespace j2735_convertor
     in_msg.offset = 60; // min
     in_msg.period = 360; // min
     in_msg.span = 180; // min
-    return in_msg;
-  }
-
-  j2735_msgs::TrafficControlBounds create_j2735_TrafficControlBounds(bool optional = true)
-  {
-    j2735_msgs::TrafficControlBounds in_msg;
-    in_msg.oldest = 1000000;
-    in_msg.reflon = -400000000;
-    in_msg.reflat = 800000000;
-
-    for(int i = 0; i < 3; i++)
-    {
-      in_msg.offsets[i].deltax = 100;
-      in_msg.offsets[i].deltay = -1364;
-    }
     return in_msg;
   }
 
@@ -223,13 +200,6 @@ namespace j2735_convertor
 
     }
 
-    j2735_msgs::TrafficControlBounds tcb;
-    for(int i = 0; i < NUM_NODES; i++)
-    {
-      tcb = create_j2735_TrafficControlBounds();
-      in_msg.bounds.push_back(tcb);
-    }
-
     return in_msg;
   }
 
@@ -248,14 +218,6 @@ namespace j2735_convertor
     cav_msgs::DailySchedule in_msg;
     in_msg.begin = ros::Duration(36000);
     in_msg.duration = ros::Duration(3600);
-    return in_msg;
-  }
-
-  cav_msgs::OffsetPoint create_cav_OffsetPoint(bool optional = true)
-  {
-    cav_msgs::OffsetPoint in_msg;
-    in_msg.deltax = 10.0;
-    in_msg.deltay = 20.0;
     return in_msg;
   }
 
@@ -281,20 +243,6 @@ namespace j2735_convertor
     in_msg.offset = ros::Duration(3600);
     in_msg.period = ros::Duration(6000);
     in_msg.span = ros::Duration(1800);
-    return in_msg;
-  }
-
-  cav_msgs::TrafficControlBounds create_cav_TrafficControlBounds(bool optional = true)
-  {
-    cav_msgs::TrafficControlBounds in_msg;
-    in_msg.oldest = ros::Time(180000);
-    in_msg.reflon = -40.0;
-    in_msg.reflat = 80.0;
-
-    for(int i = 0; i < 3; i++)
-    {
-      in_msg.offsets[i] = create_cav_OffsetPoint();
-    }
     return in_msg;
   }
 
@@ -431,13 +379,6 @@ namespace j2735_convertor
 
     }
 
-    cav_msgs::TrafficControlBounds tcb;
-    for(int i = 0; i < NUM_NODES; i++)
-    {
-      tcb = create_cav_TrafficControlBounds();
-      in_msg.bounds.push_back(tcb);
-    }
-
     return in_msg;
   }
 
@@ -459,14 +400,6 @@ namespace j2735_convertor
     ASSERT_EQ(out_msg.begin.nsec, 0);
     ASSERT_EQ(out_msg.duration.sec, in_msg.duration * units::SEC_PER_MIN);
     ASSERT_EQ(out_msg.duration.nsec, 0);
-  }
-
-  void test_OffsetPoint(
-    j2735_msgs::OffsetPoint in_msg, 
-    cav_msgs::OffsetPoint out_msg)
-  {
-    ASSERT_NEAR(out_msg.deltax, out_msg.deltax, 0.000001);
-    ASSERT_NEAR(out_msg.deltay, out_msg.deltay, 0.000001);
   }
 
   void test_PathNode(
@@ -498,24 +431,6 @@ namespace j2735_convertor
     ASSERT_EQ(out_msg.period.nsec, 0);
     ASSERT_EQ(out_msg.span.sec, in_msg.span * units::SEC_PER_MIN);
     ASSERT_EQ(out_msg.span.nsec, 0);
-  }
-
-  void test_TrafficControlBounds(
-    j2735_msgs::TrafficControlBounds in_msg, 
-    cav_msgs::TrafficControlBounds out_msg)
-  {
-    ASSERT_EQ(out_msg.oldest.sec, in_msg.oldest * units::SEC_PER_MIN);
-    ASSERT_EQ(out_msg.oldest.nsec, 0.);
-    ASSERT_NEAR(in_msg.reflon, out_msg.reflon * units::TENTH_MICRO_DEG_PER_DEG, 0.000001);
-    ASSERT_NEAR(in_msg.reflat, out_msg.reflat * units::TENTH_MICRO_DEG_PER_DEG, 0.000001);
-
-    for(int i = 0; i < 3; i++)
-    {
-      auto in_offset = in_msg.offsets[i];
-      auto out_offset = out_msg.offsets[i];
-      ASSERT_NEAR(in_offset.deltax, out_offset.deltax, 0.000001);
-      ASSERT_NEAR(in_offset.deltay, out_offset.deltay, 0.000001);
-    }
   }
 
   void test_TrafficControlDetail(
@@ -626,11 +541,6 @@ namespace j2735_convertor
     if(in_msg.geometry_exists)
     {
       test_TrafficControlGeometry(in_msg.geometry, out_msg.geometry);
-    }
-    
-    for(int i = 0; i < NUM_NODES; i++)
-    {
-      test_TrafficControlBounds(in_msg.bounds[i], out_msg.bounds[i]);
     }
   }
   
@@ -854,18 +764,6 @@ TEST(ControlMessage, convertDailyScheduleToCAV)
   test_DailySchedule(in_msg, out_msg);
 }
 
-TEST(ControlMessage, convertOffsetPointToCAV)
-{
-  // Create variables
-  j2735_msgs::OffsetPoint in_msg;
-  cav_msgs::OffsetPoint out_msg;
-
-  // Test
-  in_msg = create_j2735_OffsetPoint();
-  j2735_convertor::geofence_control::convert(in_msg, out_msg);
-  test_OffsetPoint(in_msg, out_msg);
-}
-
 TEST(ControlMessage, convertPathNodeToCAV)
 {
   // Create variables
@@ -895,24 +793,15 @@ TEST(ControlMessage, convertRepeatParamsToCAV)
   test_RepeatParams(in_msg, out_msg);
 }
 
-TEST(ControlMessage, convertTrafficControlBoundsToCAV)
-{
-  // Create variables
-  j2735_msgs::TrafficControlBounds in_msg;
-  cav_msgs::TrafficControlBounds out_msg;
-
-  // Test
-  in_msg = create_j2735_TrafficControlBounds();
-  j2735_convertor::geofence_control::convert(in_msg, out_msg);
-  test_TrafficControlBounds(in_msg, out_msg);
-}
-
-  
-
 TEST(ControlMessage, convertTrafficControlDetailToCAV)
 {
   j2735_msgs::TrafficControlDetail in_msg;
   cav_msgs::TrafficControlDetail out_msg;
+
+  // Default Case Test
+  in_msg.choice = 63;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
 
   // SIGNAL Test
   in_msg.choice = j2735_msgs::TrafficControlDetail::SIGNAL_CHOICE;
@@ -920,6 +809,26 @@ TEST(ControlMessage, convertTrafficControlDetailToCAV)
   j2735_convertor::geofence_control::convert(in_msg, out_msg);
   ASSERT_EQ(out_msg.choice, in_msg.choice);
   ASSERT_EQ(in_msg.signal, out_msg.signal);
+
+  // STOP Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::STOP_CHOICE;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+
+  // YIELD Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::YIELD_CHOICE;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+
+  // NOTOWING Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::NOTOWING_CHOICE;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+
+  // RESTRICTED Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::RESTRICTED_CHOICE;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
 
   // CLOSED Test
   in_msg.choice = j2735_msgs::TrafficControlDetail::CLOSED_CHOICE;
@@ -1051,6 +960,11 @@ TEST(ControlMessage, convertTrafficControlMessageToCAV)
   // Create variables
   j2735_msgs::TrafficControlMessage in_msg;
   cav_msgs::TrafficControlMessage out_msg;
+
+  // Test Default Case
+  in_msg.choice = 63;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
 
   // Test RESERVED
   in_msg.choice = j2735_msgs::TrafficControlMessage::RESERVED;
@@ -1314,18 +1228,6 @@ TEST(ControlMessage, convertDailyScheduleToJ2735)
   test_DailySchedule(out_msg, in_msg);
 }
 
-TEST(ControlMessage, convertOffsetPointToJ2735)
-{
-  // Create variables
-  cav_msgs::OffsetPoint in_msg;
-  j2735_msgs::OffsetPoint out_msg;
-
-  // Test
-  in_msg = create_cav_OffsetPoint();
-  j2735_convertor::geofence_control::convert(in_msg, out_msg);
-  test_OffsetPoint(out_msg, in_msg);
-}
-
 TEST(ControlMessage, convertPathNodeToJ2735)
 {
   // Create variables
@@ -1355,40 +1257,42 @@ TEST(ControlMessage, convertRepeatParamsToJ2735)
   test_RepeatParams(out_msg, in_msg);
 }
 
-TEST(ControlMessage, convertTrafficControlBoundsToJ2735)
-{
-  // Create variables
-  cav_msgs::TrafficControlBounds in_msg;
-  j2735_msgs::TrafficControlBounds out_msg;
-
-  // Test
-  in_msg = create_cav_TrafficControlBounds();
-  j2735_convertor::geofence_control::convert(in_msg, out_msg);
-  test_TrafficControlBounds(out_msg, in_msg);
-}
-
 TEST(ControlMessage, convertTrafficControlDetailToJ2735)
 {
   cav_msgs::TrafficControlDetail in_msg;
   j2735_msgs::TrafficControlDetail out_msg;
 
-  // // SIGNAL Test
-  // in_msg.choice = cav_msgs::TrafficControlDetail::SIGNAL_CHOICE;
+  // Default Case Test
+  in_msg.choice = 63;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
 
-  // int sig;
-  // for(int i = 0; i < NUM_NODES; i++)
-  // {
-  //   sig = i;
-  //   in_msg.signal.push_back(sig);
-  // }
+  // SIGNAL Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::SIGNAL_CHOICE;
+  in_msg.signal = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+  ASSERT_EQ(in_msg.signal, out_msg.signal);
 
-  // j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  // STOP Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::STOP_CHOICE;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
 
-  // ASSERT_EQ(out_msg.choice, in_msg.choice);
-  // for(int i = 0; i < NUM_NODES; i++)
-  // {
-  //   ASSERT_EQ(in_msg.signal[i], out_msg.signal[i]);
-  // }
+  // YIELD Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::YIELD_CHOICE;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+
+  // NOTOWING Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::NOTOWING_CHOICE;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
+
+  // RESTRICTED Test
+  in_msg.choice = j2735_msgs::TrafficControlDetail::RESTRICTED_CHOICE;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
 
   // CLOSED Test
   in_msg.choice = cav_msgs::TrafficControlDetail::CLOSED_CHOICE;
@@ -1520,6 +1424,11 @@ TEST(ControlMessage, convertTrafficControlMessageToJ2735)
   // Create variables
   cav_msgs::TrafficControlMessage in_msg;
   j2735_msgs::TrafficControlMessage out_msg;
+
+  // Test Default Case
+  in_msg.choice = 63;
+  j2735_convertor::geofence_control::convert(in_msg, out_msg);
+  ASSERT_EQ(out_msg.choice, in_msg.choice);
 
   // Test RESERVED
   in_msg.choice = cav_msgs::TrafficControlMessage::RESERVED;

--- a/carma-messenger-core/j2735_convertor/test/control_message_test.cpp
+++ b/carma-messenger-core/j2735_convertor/test/control_message_test.cpp
@@ -151,8 +151,8 @@ namespace j2735_convertor
   {
     j2735_msgs::TrafficControlMessageV01 in_msg;
     // # reqid ::= Id64b
-    // uint8[8] reqid
-    in_msg.reqid = {0, 1, 2, 3, 4, 5, 6, 7};
+    // j2735_msgs/Id64b reqid
+    in_msg.reqid.id = {0, 1, 2, 3, 4, 5, 6, 7};
 
     // # reqseq ::= INTEGER (0..255)
     // uint8 reqseq
@@ -167,8 +167,8 @@ namespace j2735_convertor
     in_msg.msgnum = 0;
 
     // # id Id128b, -- unique traffic control id
-    // uint8[16] id
-    in_msg.id = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+    // j2735_msgs/Id128b reqid
+    in_msg.id.id = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
 
     // # updated EpochMins
     // time updated
@@ -193,11 +193,15 @@ namespace j2735_convertor
     if(optional)
     {
       in_msg.package.label = "This Is A Label";
-      in_msg.package.tcids = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13};
+      j2735_msgs::Id128b id128b;
+      for(int i = 0; i < NUM_NODES; i++)
+      {
+        id128b.id = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+        in_msg.package.tcids.push_back(id128b);
+      }
 
       in_msg.params = create_j2735_TrafficControlParams();
       in_msg.geometry = create_j2735_TrafficControlGeometry();
-
     }
 
     return in_msg;
@@ -332,7 +336,7 @@ namespace j2735_convertor
     cav_msgs::TrafficControlMessageV01 in_msg;
     // # reqid ::= Id64b
     // uint8[8] reqid
-    in_msg.reqid = {0, 1, 2, 3, 4, 5, 6, 7};
+    in_msg.reqid.id = {0, 1, 2, 3, 4, 5, 6, 7};
 
     // # reqseq ::= INTEGER (0..255)
     // uint8 reqseq
@@ -348,7 +352,7 @@ namespace j2735_convertor
 
     // # id Id128b, -- unique traffic control id
     // uint8[16] id
-    in_msg.id = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+    in_msg.id.id = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
 
     // # updated EpochMins
     // time updated
@@ -372,7 +376,12 @@ namespace j2735_convertor
     if(optional)
     {
       in_msg.package.label = "This Is A Label";
-      in_msg.package.tcids = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+      j2735_msgs::Id128b id128b;
+      for(int i = 0; i < NUM_NODES; i++)
+      {
+        id128b.id = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+        in_msg.package.tcids.push_back(id128b);
+      }
 
       in_msg.params = create_cav_TrafficControlParams();
       in_msg.geometry = create_cav_TrafficControlGeometry();
@@ -516,11 +525,11 @@ namespace j2735_convertor
     j2735_msgs::TrafficControlMessageV01 in_msg, 
     cav_msgs::TrafficControlMessageV01 out_msg)
   {
-    ASSERT_EQ(in_msg.reqid, out_msg.reqid);
+    ASSERT_EQ(in_msg.reqid.id, out_msg.reqid.id);
     ASSERT_EQ(in_msg.reqseq, out_msg.reqseq);
     ASSERT_EQ(in_msg.msgtot, out_msg.msgtot);
     ASSERT_EQ(in_msg.msgnum, out_msg.msgnum);
-    ASSERT_EQ(in_msg.id, out_msg.id);
+    ASSERT_EQ(in_msg.id.id, out_msg.id.id);
     ASSERT_EQ(out_msg.updated.sec, in_msg.updated * units::SEC_PER_MIN);
     ASSERT_EQ(out_msg.updated.nsec, 0);
 
@@ -528,7 +537,10 @@ namespace j2735_convertor
     if(in_msg.package_exists)
     {
       ASSERT_EQ(in_msg.package.label, out_msg.package.label);
-      ASSERT_EQ(in_msg.package.tcids, out_msg.package.tcids);
+      for(int i = 0; i < NUM_NODES; i++)
+      {
+        ASSERT_EQ(in_msg.package.tcids[i].id, out_msg.package.tcids[i].id);
+      }
     }
 
     ASSERT_EQ(in_msg.params_exists, out_msg.params_exists);


### PR DESCRIPTION
# PR Details
## Description

<!--- Describe your changes in detail -->

## Related Issue

https://github.com/usdot-fhwa-stol/carma-platform/issues/749

## Motivation and Context

This change adds convertors for changing new J2735 messages into their cav counterparts. Most of these changes are altering units or variable types, no true changes. 

The unit tests themselves are written mostly in helper functions - one for each message type. Without helper functions, writing a unit test for a message that contains multiple message types inside was just far too tedious. 

Current areas of concern:
 - Should the helper functions in control_message_test.cpp be moved?
 - Still a few possible minor changes to the message structures.

## How Has This Been Tested?

With these changes are unit tests, which test every single message convertor (often multiple times). It has not been tested with an actual message from either side. 

## Types of changes

Not entirely sure - I believe that this is a non-breaking fix, since all of the old code is still there. That said, to run the convertor you must now pull the integration/routing branch of carma-msgs, though that is theoretically also non-breaking. 

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.