### PR TITLE
Updated message types in j2735_convertor

### DIFF
--- a/carma-messenger-core/j2735_convertor/src/j2735_convertor.cpp
+++ b/carma-messenger-core/j2735_convertor/src/j2735_convertor.cpp
@@ -145,14 +145,14 @@ void J2735Convertor::j2735MapHandler(const j2735_msgs::MapDataConstPtr& message)
   converted_map_pub_.publish(converted_msg);       // Publish converted message
 }
 
-void J2735Convertor::ControlMessageHandler(const cav_msgs::ControlMessageConstPtr& message) {
-  j2735_msgs::ControlMessage converted_msg;
+void J2735Convertor::ControlMessageHandler(const cav_msgs::TrafficControlMessageConstPtr& message) {
+  j2735_msgs::TrafficControlMessage converted_msg;
   j2735_convertor::geofence_control::convert(*message, converted_msg);  // Convert message
   outbound_j2735_geofence_control_pub_.publish(converted_msg);       // Publish converted message
 }
 
-void J2735Convertor::j2735ControlMessageHandler(const j2735_msgs::ControlMessageConstPtr& message) {
-  cav_msgs::ControlMessage converted_msg;
+void J2735Convertor::j2735ControlMessageHandler(const j2735_msgs::TrafficControlMessageConstPtr& message) {
+  cav_msgs::TrafficControlMessage converted_msg;
   j2735_convertor::geofence_control::convert(*message, converted_msg);  // Convert message
   converted_geofence_control_pub_.publish(converted_msg);       // Publish converted message
 }

--- a/carma-messenger-core/j2735_convertor/src/j2735_convertor.h
+++ b/carma-messenger-core/j2735_convertor/src/j2735_convertor.h
@@ -21,13 +21,13 @@
 #include <j2735_msgs/BSM.h>
 #include <j2735_msgs/SPAT.h>
 #include <j2735_msgs/MapData.h>
-#include <j2735_msgs/ControlMessage.h>
+#include <j2735_msgs/TrafficControlMessage.h>
 #include <j2735_msgs/ControlRequest.h>
 #include <cav_msgs/SystemAlert.h>
 #include <cav_msgs/BSM.h>
 #include <cav_msgs/SPAT.h>
 #include <cav_msgs/MapData.h>
-#include <cav_msgs/ControlMessage.h>
+#include <cav_msgs/TrafficControlMessage.h>
 #include <cav_msgs/ControlRequest.h>
 #include <cav_msgs/MapData.h>
 #include <j2735_convertor/bsm_convertor.h>
@@ -126,18 +126,18 @@ private:
   void j2735MapHandler(const j2735_msgs::MapDataConstPtr& message);
 
   /**
-   * @brief Converts cav_msgs::ControlMessage messages to j2735_msgs::ControlMessage and publishes the converted messages
+   * @brief Converts cav_msgs::TrafficControlMessage messages to j2735_msgs::TrafficControlMessage and publishes the converted messages
    *
    * @param message The message to convert
    */
-  void ControlMessageHandler(const cav_msgs::ControlMessageConstPtr& message);
+  void ControlMessageHandler(const cav_msgs::TrafficControlMessageConstPtr& message);
 
   /**
-   * @brief Converts j2735_msgs::ControlMessage messages to cav_msgs::ControlMessage and publishes the converted messages
+   * @brief Converts j2735_msgs::TrafficControlMessage messages to cav_msgs::TrafficControlMessage and publishes the converted messages
    *
    * @param message The message to convert
    */
-  void j2735ControlMessageHandler(const j2735_msgs::ControlMessageConstPtr& message);
+  void j2735ControlMessageHandler(const j2735_msgs::TrafficControlMessageConstPtr& message);
 
     /**
    * @brief Converts cav_msgs::ControlRequest messages to j2735_msgs::ControlRequest and publishes the converted messages


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

The files j2735_convertor.cpp and .h still had references to the old COntrolMessage message types. These messages were replaced by the TrafficControlMessage with PR: https://github.com/usdot-fhwa-stol/carma-messenger/pull/23, but this file was forgotten. 

## Related Issue

usdot-fhwa-stol/carma-platform#749

## Motivation and Context

Adding forgotten features from the above PR. 

## How Has This Been Tested?

This was tested by confirming these re-namings as the only changes and building the j2735_convertor. 

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [x] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.