### PR TITLE
update Mobility Request header ids and params number

### DIFF
--- a/carma-messenger-core/carma-messenger/launch/carma-messenger.launch
+++ b/carma-messenger-core/carma-messenger/launch/carma-messenger.launch
@@ -31,7 +31,8 @@
   <env name="JAVA_OPTS" value="$(arg JVM_LOG_OPTS)"/>
   <!-- Generate log name configuration file -->
   <param name="log_name" type="str" command="$(find carma-messenger)/scripts/generate_log_name.sh"/>
-
+    <remap from="outbound_binary_msg" to="comms/outbound_binary_msg"/>
+    <remap from="inbound_binary_msg" to="comms/inbound_binary_msg"/>
   <!-- ROS Bag -->
   <node if="$(arg use_rosbag)" pkg="rosbag" type="record" name="rosbag_node" args="record -o /opt/carma/logs/ --lz4 -a -x '/rosout(.*)'" />
 
@@ -43,12 +44,12 @@
     <remap from="outgoing_bsm" to="bsm_outbound"/>
   </node>
   
-  <!-- Message Consumer Node -->
+  <!-- Message Consumer Node 
   <node pkg="message" type="message" name="message_consumer" args="gov.dot.fhwa.saxton.carma.message.MessageConsumer">
     <rosparam command="load" file="$(find message)/message/config/MessageParams.yaml"/>
     <remap from="outbound_binary_msg" to="comms/outbound_binary_msg"/>
     <remap from="inbound_binary_msg" to="comms/inbound_binary_msg"/>
-  </node>
+  </node>-->
 
   <!-- System Alert Publisher to publish simulated DRIVERS_READY status -->
   <node pkg="rostopic" type="rostopic" name="drivers_ready_rostopic_pub"

--- a/carma-messenger-core/carma-messenger/launch/carma-messenger.launch
+++ b/carma-messenger-core/carma-messenger/launch/carma-messenger.launch
@@ -44,12 +44,12 @@
     <remap from="outgoing_bsm" to="bsm_outbound"/>
   </node>
   
-  <!-- Message Consumer Node 
+  <!-- Message Consumer Node -->
   <node pkg="message" type="message" name="message_consumer" args="gov.dot.fhwa.saxton.carma.message.MessageConsumer">
     <rosparam command="load" file="$(find message)/message/config/MessageParams.yaml"/>
     <remap from="outbound_binary_msg" to="comms/outbound_binary_msg"/>
     <remap from="inbound_binary_msg" to="comms/inbound_binary_msg"/>
-  </node>-->
+  </node>
 
   <!-- System Alert Publisher to publish simulated DRIVERS_READY status -->
   <node pkg="rostopic" type="rostopic" name="drivers_ready_rostopic_pub"

--- a/carma-messenger-core/truck_inspection_plugin/config/parameters.yaml
+++ b/carma-messenger-core/truck_inspection_plugin/config/parameters.yaml
@@ -1,2 +1,2 @@
 # Number of Key-Value entries in safety log
-num_of_entries: 14
+num_of_entries: 13

--- a/carma-messenger-core/truck_inspection_plugin/src/truck_inspection_plugin.cpp
+++ b/carma-messenger-core/truck_inspection_plugin/src/truck_inspection_plugin.cpp
@@ -51,6 +51,34 @@ namespace truck_inspection_plugin
     {
         cav_msgs::MobilityRequest msg;
         msg.strategy = TruckInspectionPlugin::INSPECTION_STRATEGY;
+        //add header temporarily for ACE testing, will be removed once the mobilityRequest message node is fixed
+        cav_msgs::MobilityHeader msg_out_header;
+        msg_out_header.sender_id =  "USDOT-10003";
+        msg_out_header.recipient_id="USDOT-10003";
+        msg_out_header.sender_bsm_id="10ABCDEF";
+        msg_out_header.plan_id= "11111111-2222-3333-AAAA-111111111111";
+        msg_out_header.timestamp= 9223372036854775807;
+        msg.header = msg_out_header;
+        msg.expiration=1523372036854775807;
+        msg.strategy_params="abs";
+        cav_msgs::PlanType plan_type;
+        plan_type.type=4;
+        msg.plan_type = plan_type;
+        cav_msgs::LocationECEF location;
+        location.ecef_x=0;
+        location.ecef_y=0;
+        location.ecef_z=0;
+        location.timestamp=1223372036854775807; 
+        msg.location=location;
+        location.timestamp= 9023372036854775807;
+        cav_msgs::Trajectory trajectory;
+        trajectory.location=location;
+        cav_msgs::LocationOffsetECEF offset;
+        offset.offset_x=0;
+        offset.offset_y=0;
+        offset.offset_z=0;
+        trajectory.offsets.push_back(offset);
+        msg.trajectory=trajectory;
         mr_pub_.publish(msg);
         // reset safety log
         this->safety_log_ = "";

--- a/carma-messenger-core/truck_inspection_plugin/src/truck_inspection_plugin.cpp
+++ b/carma-messenger-core/truck_inspection_plugin/src/truck_inspection_plugin.cpp
@@ -51,34 +51,6 @@ namespace truck_inspection_plugin
     {
         cav_msgs::MobilityRequest msg;
         msg.strategy = TruckInspectionPlugin::INSPECTION_STRATEGY;
-        //add header temporarily for ACE testing, will be removed once the mobilityRequest message node is fixed
-        cav_msgs::MobilityHeader msg_out_header;
-        msg_out_header.sender_id =  "USDOT-10003";
-        msg_out_header.recipient_id="USDOT-10003";
-        msg_out_header.sender_bsm_id="10ABCDEF";
-        msg_out_header.plan_id= "11111111-2222-3333-AAAA-111111111111";
-        msg_out_header.timestamp= 9223372036854775807;
-        msg.header = msg_out_header;
-        msg.expiration=1523372036854775807;
-        msg.strategy_params="abs";
-        cav_msgs::PlanType plan_type;
-        plan_type.type=4;
-        msg.plan_type = plan_type;
-        cav_msgs::LocationECEF location;
-        location.ecef_x=0;
-        location.ecef_y=0;
-        location.ecef_z=0;
-        location.timestamp=1223372036854775807; 
-        msg.location=location;
-        location.timestamp= 9023372036854775807;
-        cav_msgs::Trajectory trajectory;
-        trajectory.location=location;
-        cav_msgs::LocationOffsetECEF offset;
-        offset.offset_x=0;
-        offset.offset_y=0;
-        offset.offset_z=0;
-        trajectory.offsets.push_back(offset);
-        msg.trajectory=trajectory;
         mr_pub_.publish(msg);
         // reset safety log
         this->safety_log_ = "";


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
Update mobility request header with values temprarily. Once the message node for mobility request fix is done, it will be updated.
## Description

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/871
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
ACE testing
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Integration testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
C++ and ymal files
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.