### PR TITLE
changing default string

### DIFF
--- a/carma-messenger-core/cpp_message/include/MobilityHeader_Message.h
+++ b/carma-messenger-core/cpp_message/include/MobilityHeader_Message.h
@@ -25,7 +25,7 @@ namespace cpp_message
         static const int STATIC_ID_MAX_LENGTH=16;
         std::string BSM_ID_DEFAULT="00000000";
         const int BSM_ID_LENGTH=BSM_ID_DEFAULT.length();
-        std::string STRING_DEFAULT="[]";
+        std::string STRING_DEFAULT="UNSET";
         static const int TIMESTAMP_MESSAGE_LENGTH=19;
         std::string GUID_DEFAULT= "00000000-0000-0000-0000-000000000000";
         const int GUID_LENGTH=GUID_DEFAULT.length();

--- a/carma-messenger-core/cpp_message/include/MobilityOperation_Message.h
+++ b/carma-messenger-core/cpp_message/include/MobilityOperation_Message.h
@@ -27,6 +27,7 @@ namespace cpp_message
             static const int STRATEGY_PARAMS_MIN_LENGTH=2;
             static const int STRATEGY_PARAMS_MAX_LENGTH=1000;
             static const int MOBILITY_OPERATION_TEST_ID=243;
+            std::string STRATEGY_PARAMS_STRING_DEFAULT="[]";
         
         public:
         /**

--- a/carma-messenger-core/cpp_message/include/MobilityPath_Message.h
+++ b/carma-messenger-core/cpp_message/include/MobilityPath_Message.h
@@ -21,7 +21,6 @@ namespace cpp_message
     class Mobility_Path
     {
         private:
-        std::string PATH_STRING_DEFAULT="UNKNOWN";
         static const int MAX_POINTS_IN_MESSAGE=60; //The maximum number of points which can be included in a mobility message containing a trajectory over DSRC
         //Location Range for x and y
         static const long LOCATION_MIN=-638363700;

--- a/carma-messenger-core/cpp_message/include/MobilityRequest_Message.h
+++ b/carma-messenger-core/cpp_message/include/MobilityRequest_Message.h
@@ -22,7 +22,6 @@ namespace cpp_message
         private:
         static const int MOBILITY_REQUEST_TEST_ID_=240;
 
-        std::string REQUEST_STRING_DEFAULT="UNKNOWN";
         static const int STRATEGY_MIN_LENGTH=2;
         static const int STRATEGY_MAX_LENGTH=50;
         //Urgency min and max

--- a/carma-messenger-core/cpp_message/include/MobilityResponse_Message.h
+++ b/carma-messenger-core/cpp_message/include/MobilityResponse_Message.h
@@ -21,7 +21,6 @@ namespace cpp_message
     class Mobility_Response
     {
             private:
-            std::string RESPONSE_STRING_DEFAULT="UNKNOWN";
             static const int MOBILITY_RESPONSE_TEST_ID=241;
             static const int URGENCY_MIN=0;
             static const int URGENCY_MAX=1000;

--- a/carma-messenger-core/cpp_message/src/MobilityOperation_Message.cpp
+++ b/carma-messenger-core/cpp_message/src/MobilityOperation_Message.cpp
@@ -128,7 +128,7 @@ namespace cpp_message
                     strategy_params +=message->value.choice.TestMessage03.body.operationParams.buf[i];
                 }
             }
-            else strategy_params=Header_constant.STRING_DEFAULT;
+            else strategy_params=STRATEGY_PARAMS_STRING_DEFAULT;
             
             output.strategy_params=strategy_params;
 
@@ -265,8 +265,8 @@ namespace cpp_message
         string_size=strategy_params.size();
         if(string_size<STRATEGY_PARAMS_MIN_LENGTH || string_size>STRATEGY_PARAMS_MAX_LENGTH){
             ROS_WARN("Unacceptable strategy_params value, changing to default");
-            strategy_params=Header.STRING_DEFAULT;
-            string_size=Header.STRING_DEFAULT.size();
+            strategy_params=STRATEGY_PARAMS_STRING_DEFAULT;
+            string_size=STRATEGY_PARAMS_STRING_DEFAULT.size();
         }
         uint8_t string_content_params[string_size];
         for(size_t i=0;i<string_size;i++)

--- a/carma-messenger-core/cpp_message/src/MobilityPath_Message.cpp
+++ b/carma-messenger-core/cpp_message/src/MobilityPath_Message.cpp
@@ -51,7 +51,7 @@ namespace cpp_message
                     sender_id +=message->value.choice.TestMessage02.header.hostStaticId.buf[i];
                 }
             }
-            else sender_id=PATH_STRING_DEFAULT;
+            else sender_id=Header_constant.STRING_DEFAULT;
 
             header.sender_id=sender_id;
 
@@ -63,7 +63,7 @@ namespace cpp_message
                     recipient_id +=message->value.choice.TestMessage02.header.targetStaticId.buf[i];
                 }
             }
-            else recipient_id=PATH_STRING_DEFAULT;
+            else recipient_id=Header_constant.STRING_DEFAULT;
 
             header.recipient_id=recipient_id;
             
@@ -203,8 +203,8 @@ namespace cpp_message
         size_t string_size=sender_id.size();
         if(string_size<Header.STATIC_ID_MIN_LENGTH || string_size>Header.STATIC_ID_MAX_LENGTH){
             ROS_WARN("Unacceptable host id value, changing to default");
-            sender_id=PATH_STRING_DEFAULT;
-            string_size=PATH_STRING_DEFAULT.size();
+            sender_id=Header.STRING_DEFAULT;
+            string_size=Header.STRING_DEFAULT.size();
         }
         uint8_t string_content_hostId[string_size];
         for(size_t i=0;i<string_size;i++)
@@ -218,8 +218,8 @@ namespace cpp_message
         string_size=recipient_id.size();
         if(string_size<Header.STATIC_ID_MIN_LENGTH || string_size> Header.STATIC_ID_MAX_LENGTH){
             ROS_WARN("Unacceptable recipient id value, changing to default");
-            recipient_id=PATH_STRING_DEFAULT;
-            string_size=PATH_STRING_DEFAULT.size();
+            recipient_id=Header.STRING_DEFAULT;
+            string_size=Header.STRING_DEFAULT.size();
         }
         uint8_t string_content_targetId[string_size];
         for(size_t i=0;i<string_size;i++)

--- a/carma-messenger-core/cpp_message/src/MobilityRequest_Message.cpp
+++ b/carma-messenger-core/cpp_message/src/MobilityRequest_Message.cpp
@@ -53,7 +53,7 @@ namespace cpp_message
                     sender_id +=message->value.choice.TestMessage00.header.hostStaticId.buf[i];
                 }
             }
-            else sender_id=REQUEST_STRING_DEFAULT;
+            else sender_id=Header_constant.STRING_DEFAULT;
 
             header.sender_id=sender_id;
 
@@ -65,7 +65,7 @@ namespace cpp_message
                     recipient_id +=message->value.choice.TestMessage00.header.targetStaticId.buf[i];
                 }
             }
-            else recipient_id=REQUEST_STRING_DEFAULT;
+            else recipient_id=Header_constant.STRING_DEFAULT;
 
             header.recipient_id=recipient_id;
             
@@ -118,7 +118,7 @@ namespace cpp_message
                     strategy +=message->value.choice.TestMessage00.body.strategy.buf[i];
                 }
             }
-            else strategy=REQUEST_STRING_DEFAULT;
+            else strategy=Header_constant.STRING_DEFAULT;
 
             output.strategy=strategy;
             //plan type   
@@ -277,8 +277,8 @@ namespace cpp_message
         size_t string_size=sender_id.size();
         if(string_size<Header.STATIC_ID_MIN_LENGTH || string_size>Header.STATIC_ID_MAX_LENGTH){
             ROS_WARN("Unacceptable host id value, changing to default");
-            sender_id=REQUEST_STRING_DEFAULT;
-            string_size=REQUEST_STRING_DEFAULT.size();
+            sender_id=Header.STRING_DEFAULT;
+            string_size=Header.STRING_DEFAULT.size();
         }
         uint8_t string_content_hostId[string_size];
         for(size_t i=0;i<string_size;i++)
@@ -292,8 +292,8 @@ namespace cpp_message
         string_size=recipient_id.size();
         if(string_size<Header.STATIC_ID_MIN_LENGTH || string_size>Header.STATIC_ID_MAX_LENGTH){
             ROS_WARN("Unacceptable recipient id value, changing to default");
-            recipient_id=REQUEST_STRING_DEFAULT;
-            string_size=REQUEST_STRING_DEFAULT.size();
+            recipient_id=Header.STRING_DEFAULT;
+            string_size=Header.STRING_DEFAULT.size();
         }
         uint8_t string_content_targetId[string_size];
         for(size_t i=0;i<string_size;i++)
@@ -361,8 +361,8 @@ namespace cpp_message
         string_size=strategy.size();
         if(string_size<STRATEGY_MIN_LENGTH || string_size>STRATEGY_MAX_LENGTH){
             ROS_WARN("Unacceptable strategy value, changing to default");
-            strategy=REQUEST_STRING_DEFAULT;
-            string_size=REQUEST_STRING_DEFAULT.size();
+            strategy=Header.STRING_DEFAULT;
+            string_size=Header.STRING_DEFAULT.size();
         }        
         uint8_t string_content_strategy[string_size];
         for(size_t i=0;i<string_size;i++)
@@ -429,8 +429,8 @@ namespace cpp_message
         size_t params_string_size=params_string.size();
         if(params_string_size<STRATEGY_PARAMS_MIN_LENGTH || params_string_size>STRATEGY_PARAMS_MAX_LENGTH){
             ROS_WARN("Unacceptable strategy_params value, changing to default");
-            params_string=REQUEST_STRING_DEFAULT;
-            params_string_size=REQUEST_STRING_DEFAULT.size();
+            params_string=Header.STRING_DEFAULT;
+            params_string_size=Header.STRING_DEFAULT.size();
         }
         uint8_t string_content_params[params_string_size];
         for(size_t i=0;i<params_string_size;i++)

--- a/carma-messenger-core/cpp_message/src/MobilityResponse_Message.cpp
+++ b/carma-messenger-core/cpp_message/src/MobilityResponse_Message.cpp
@@ -52,7 +52,7 @@ namespace cpp_message
                     sender_id +=message->value.choice.TestMessage01.header.hostStaticId.buf[i];
                 }
             }
-            else sender_id=RESPONSE_STRING_DEFAULT;
+            else sender_id=Header_constant.STRING_DEFAULT;
 
             header.sender_id=sender_id;
 
@@ -64,7 +64,7 @@ namespace cpp_message
                     recipient_id +=message->value.choice.TestMessage01.header.targetStaticId.buf[i];
                 }
             }
-            else recipient_id=RESPONSE_STRING_DEFAULT;
+            else recipient_id=Header_constant.STRING_DEFAULT;
 
             header.recipient_id=recipient_id;
             
@@ -148,8 +148,8 @@ namespace cpp_message
         size_t string_size=sender_id.size();
         if(string_size<Header.STATIC_ID_MIN_LENGTH || string_size>Header.STATIC_ID_MAX_LENGTH){
             ROS_WARN("Unacceptable host id value, changing to default");
-            sender_id=RESPONSE_STRING_DEFAULT;
-            string_size=RESPONSE_STRING_DEFAULT.size();
+            sender_id=Header.STRING_DEFAULT;
+            string_size=Header.STRING_DEFAULT.size();
         }
         uint8_t string_content_hostId[string_size];
         for(size_t i=0;i<string_size;i++)
@@ -163,8 +163,8 @@ namespace cpp_message
         string_size=recipient_id.size();
         if(string_size<Header.STATIC_ID_MIN_LENGTH || string_size>Header.STATIC_ID_MAX_LENGTH){
             ROS_WARN("Unacceptable recipient id value, changing to default");
-            recipient_id=RESPONSE_STRING_DEFAULT;
-            string_size=RESPONSE_STRING_DEFAULT.size();
+            recipient_id=Header.STRING_DEFAULT;
+            string_size=Header.STRING_DEFAULT.size();
         }
         uint8_t string_content_targetId[string_size];
         for(size_t i=0;i<string_size;i++)


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This change redefines the default string for mobility messages to "UNSET". MobilityOperation Strategy params default is changed to "[ ]"
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.