### PR TITLE
If the human-readable print is uncommented, the code could crash

### DIFF
--- a/carma-messenger-core/cpp_message/src/BSM_Message.cpp
+++ b/carma-messenger-core/cpp_message/src/BSM_Message.cpp
@@ -204,9 +204,9 @@ namespace cpp_message
         free(bsm_msg);
         //encode message
         ec=uper_encode_to_buffer(&asn_DEF_MessageFrame, 0 , message , buffer , buffer_size);
-        free(message);
         // Uncomment below to enable logging in human readable form
         //asn_fprint(fp, &asn_DEF_MessageFrame, message);
+        free(message);
         
         //log a warning if that fails
         if(ec.encoded == -1) {


### PR DESCRIPTION
The potential bug is "use after free".

If `message` is freed before being used, depending on the local
implementation of `free`, the pointers within it might be zeroed or be
otherwise made invalid, and `asn_fprint` would then crash trying to
dereference those pointers. This change moves freeing of the buffer to
after its final use.

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/usdot-fhwa-stol/carma-platform/issues/971

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.