### PR TITLE
Possibly lose one byte when copying formatted data

### DIFF
--- a/carma-messenger-core/cpp_message/src/BSM_Message.cpp
+++ b/carma-messenger-core/cpp_message/src/BSM_Message.cpp
@@ -204,9 +204,9 @@ namespace cpp_message
         free(bsm_msg);
         //encode message
         ec=uper_encode_to_buffer(&asn_DEF_MessageFrame, 0 , message , buffer , buffer_size);
-        free(message);
         // Uncomment below to enable logging in human readable form
         //asn_fprint(fp, &asn_DEF_MessageFrame, message);
+        free(message);
         
         //log a warning if that fails
         if(ec.encoded == -1) {

--- a/carma-messenger-core/cpp_message/src/BSM_Message.cpp
+++ b/carma-messenger-core/cpp_message/src/BSM_Message.cpp
@@ -216,7 +216,7 @@ namespace cpp_message
         }
         
         //copy to byte array msg
-        size_t array_length=ec.encoded / 8;
+        size_t array_length=(ec.encoded + 7) / 8;
         std::vector<uint8_t> b_array(array_length);
         for(size_t i=0;i<array_length;i++)b_array[i]=buffer[i];
                 

--- a/carma-messenger-core/cpp_message/src/MobilityOperation_Message.cpp
+++ b/carma-messenger-core/cpp_message/src/MobilityOperation_Message.cpp
@@ -286,7 +286,7 @@ namespace cpp_message
         }
         
         //copy to byte array msg
-        size_t array_length=ec.encoded / 8;
+        size_t array_length=(ec.encoded + 7) / 8;
         std::vector<uint8_t> b_array(array_length);
         for(size_t i=0;i<array_length;i++)b_array[i]=buffer[i];
                 

--- a/carma-messenger-core/cpp_message/src/MobilityPath_Message.cpp
+++ b/carma-messenger-core/cpp_message/src/MobilityPath_Message.cpp
@@ -367,7 +367,7 @@ namespace cpp_message
         }
 
         //copy to byte array msg
-        size_t array_length=ec.encoded/8;
+        size_t array_length=(ec.encoded + 7) / 8;
         std::vector<uint8_t> b_array(array_length);
         for(size_t i = 0; i < array_length; i++) b_array[i] = buffer[i];
         

--- a/carma-messenger-core/cpp_message/src/MobilityRequest_Message.cpp
+++ b/carma-messenger-core/cpp_message/src/MobilityRequest_Message.cpp
@@ -559,7 +559,7 @@ namespace cpp_message
             return boost::optional<std::vector<uint8_t>>{}; 
         }     
         //copy to byte array msg
-        size_t array_length=ec.encoded/8;
+        size_t array_length=(ec.encoded + 7) / 8;
         std::vector<uint8_t> b_array(array_length);
         for(size_t i = 0; i < array_length; i++) 
         {

--- a/carma-messenger-core/cpp_message/src/MobilityResponse_Message.cpp
+++ b/carma-messenger-core/cpp_message/src/MobilityResponse_Message.cpp
@@ -245,7 +245,7 @@ namespace cpp_message
         }
         
         //copy to byte array msg
-        size_t array_length=ec.encoded / 8;
+        size_t array_length=(ec.encoded + 7) / 8;
         std::vector<uint8_t> b_array(array_length);
         for(size_t i=0;i<array_length;i++)b_array[i]=buffer[i];
         


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This is ascertained solely by inspection. I am not yet able to build and test the system. That said...

My understanding is that `uper_encode_to_buffer` provides, in the `encoded` member of the returned structure, the number of bits of packed data that were formatted. Unless there is a guarantee that the number of bits will always be a multiple of 8, there appears to be a possibility of losing the last byte.

<!--- Describe your changes in detail -->
In order to ensure that the final bits (when `ec.encoded % 8 != 0`) are copied, one additional byte must be copied. Therefore, instead of simply `ec.encoded / 8`, the extra bits must be taken into account with `(ec.encoded + 7) / 8`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
https://github.com/usdot-fhwa-stol/carma-platform/issues/972

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
It has not been tested. This was discovered solely by inspection.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.