### PR TITLE
Fix/gradle

### DIFF
--- a/carma-messenger-core/Dockerfile
+++ b/carma-messenger-core/Dockerfile
@@ -17,6 +17,11 @@ FROM usdotfhwastol/carma-base:3.7.0 as setup
 RUN mkdir ~/src
 COPY --chown=carma . /home/carma/src/
 RUN ~/src/docker/checkout.bash
+
+RUN cd ~/ && \
+    wget https://services.gradle.org/distributions/gradle-4.10.2-all.zip && \
+    sudo chmod 777 ~/gradle-4.10.2-all.zip
+
 RUN ~/src/docker/install.sh
 FROM usdotfhwastol/carma-base:3.7.0
 

--- a/carma-messenger-core/Dockerfile
+++ b/carma-messenger-core/Dockerfile
@@ -19,8 +19,11 @@ COPY --chown=carma . /home/carma/src/
 RUN ~/src/docker/checkout.bash
 
 RUN cd ~/ && \
-    wget https://services.gradle.org/distributions/gradle-4.10.2-all.zip && \
-    sudo chmod 777 ~/gradle-4.10.2-all.zip
+    wget https://services.gradle.org/distributions/gradle-4.10.2-bin.zip && \
+    sudo chmod 777 ~/gradle-4.10.2-bin.zip && \
+    mkdir -p /home/carma/.gradle/wrapper/dists/gradle-4.10.2-bin/cghg6c4gf4vkiutgsab8yrnwv/ && \
+    mv ~/gradle-4.10.2-bin.zip /home/carma/.gradle/wrapper/dists/gradle-4.10.2-bin/cghg6c4gf4vkiutgsab8yrnwv/gradle-4.10.2-bin.zip
+
 
 RUN ~/src/docker/install.sh
 FROM usdotfhwastol/carma-base:3.7.0

--- a/carma-messenger-core/Dockerfile
+++ b/carma-messenger-core/Dockerfile
@@ -12,27 +12,15 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 
-FROM usdotfhwastol/carma-base:3.7.0 as setup
+FROM usdotfhwastolcandidate/carma-base:candidate as setup
 
 RUN mkdir ~/src
 COPY --chown=carma . /home/carma/src/
 RUN ~/src/docker/checkout.bash
 
-RUN cd ~/ && \
-    wget https://services.gradle.org/distributions/gradle-4.10.2-bin.zip && \
-    sudo chmod 777 ~/gradle-4.10.2-bin.zip && \
-    mkdir -p /home/carma/.gradle/wrapper/dists/gradle-4.10.2-bin/cghg6c4gf4vkiutgsab8yrnwv/ && \
-    mv ~/gradle-4.10.2-bin.zip /home/carma/.gradle/wrapper/dists/gradle-4.10.2-bin/cghg6c4gf4vkiutgsab8yrnwv/gradle-4.10.2-bin.zip
-
-RUN cd ~/ && \
-    wget https://services.gradle.org/distributions/gradle-2.14.1-bin.zip && \
-    sudo chmod 777 ~/gradle-2.14.1-bin.zip && \
-    mkdir -p /home/carma/.gradle/wrapper/dists/gradle-2.14.1-bin/ && \
-    mv ~/gradle-2.14.1-bin.zip /home/carma/.gradle/wrapper/dists/gradle-2.14.1-bin/gradle-2.14.1-bin.zip
-
 
 RUN ~/src/docker/install.sh
-FROM usdotfhwastol/carma-base:3.7.0
+FROM usdotfhwastolcandidate/carma-base:candidate
 
 ARG BUILD_DATE="NULL"
 ARG VERSION="NULL"

--- a/carma-messenger-core/Dockerfile
+++ b/carma-messenger-core/Dockerfile
@@ -24,6 +24,12 @@ RUN cd ~/ && \
     mkdir -p /home/carma/.gradle/wrapper/dists/gradle-4.10.2-bin/cghg6c4gf4vkiutgsab8yrnwv/ && \
     mv ~/gradle-4.10.2-bin.zip /home/carma/.gradle/wrapper/dists/gradle-4.10.2-bin/cghg6c4gf4vkiutgsab8yrnwv/gradle-4.10.2-bin.zip
 
+RUN cd ~/ && \
+    wget https://services.gradle.org/distributions/gradle-2.14.1-bin.zip && \
+    sudo chmod 777 ~/gradle-2.14.1-bin.zip && \
+    mkdir -p /home/carma/.gradle/wrapper/dists/gradle-2.14.1-bin/ && \
+    mv ~/gradle-2.14.1-bin.zip /home/carma/.gradle/wrapper/dists/gradle-2.14.1-bin/gradle-2.14.1-bin.zip
+
 
 RUN ~/src/docker/install.sh
 FROM usdotfhwastol/carma-base:3.7.0

--- a/carma-messenger-core/cpp_message/CMakeLists.txt
+++ b/carma-messenger-core/cpp_message/CMakeLists.txt
@@ -11,7 +11,6 @@ set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
 	cav_msgs
-	cav_srvs
 	j2735_msgs
 	bondcpp
 	roscpp

--- a/carma-messenger-core/j2735_convertor/CMakeLists.txt
+++ b/carma-messenger-core/j2735_convertor/CMakeLists.txt
@@ -9,7 +9,6 @@ set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 ## Find catkin macros and libraries
 set(DEPS
   cav_msgs
-  cav_srvs
   j2735_msgs
   roscpp
   carma_utils

--- a/carma-messenger-core/j2735_convertor/package.xml
+++ b/carma-messenger-core/j2735_convertor/package.xml
@@ -9,7 +9,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <depend>cav_msgs</depend>
-  <depend>cav_srvs</depend>
   <depend>j2735_msgs</depend>
   <depend>roscpp</depend>
   <depend>carma_utils</depend>

--- a/carma-messenger-core/message/CMakeLists.txt
+++ b/carma-messenger-core/message/CMakeLists.txt
@@ -29,7 +29,6 @@ find_package(catkin REQUIRED
 	rosjava_build_tools
         rosjava_messages #genjava was here
         cav_msgs
-        cav_srvs
         j2735_msgs
         rosjava_utils
 )

--- a/carma-messenger-core/message/gradle/wrapper/gradle-wrapper.properties
+++ b/carma-messenger-core/message/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,8 @@
 #Mon Aug 21 17:10:50 EDT 2017
-#distributionBase=GRADLE_USER_HOME
-#distributionPath=wrapper/dists
-#zipStoreBase=GRADLE_USER_HOME
-#zipStorePath=wrapper/dists
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
 # Change the distributionUrl to the following to download the gradle version for source builds
 #distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
 distributionUrl=file\:/home/carma/.gradle/wrapper/dists/gradle-4.10.2-bin/cghg6c4gf4vkiutgsab8yrnwv/gradle-4.10.2-bin.zip

--- a/carma-messenger-core/message/gradle/wrapper/gradle-wrapper.properties
+++ b/carma-messenger-core/message/gradle/wrapper/gradle-wrapper.properties
@@ -4,5 +4,5 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 # Change the distributionUrl to the following to download the gradle version for source builds
-#distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
-distributionUrl=file\:/home/carma/.gradle/wrapper/dists/gradle-4.10.2-bin/cghg6c4gf4vkiutgsab8yrnwv/gradle-4.10.2-bin.zip
+#distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip
+distributionUrl=file\:/home/carma/.gradle/wrapper/dists/gradle-2.14.1-bin/gradle-2.14.1-bin.zip

--- a/carma-messenger-core/message/gradle/wrapper/gradle-wrapper.properties
+++ b/carma-messenger-core/message/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,8 @@
 #Mon Aug 21 17:10:50 EDT 2017
-distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
-zipStorePath=wrapper/dists
+#distributionBase=GRADLE_USER_HOME
+#distributionPath=wrapper/dists
+#zipStoreBase=GRADLE_USER_HOME
+#zipStorePath=wrapper/dists
 # Change the distributionUrl to the following to download the gradle version for source builds
 #distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
-distributionUrl=/home/carma/gradle-4.10.2-all.zip
+distributionUrl=/home/carma/.gradle/wrapper/dists/gradle-4.10.2-bin/cghg6c4gf4vkiutgsab8yrnwv/gradle-4.10.2-bin.zip

--- a/carma-messenger-core/message/gradle/wrapper/gradle-wrapper.properties
+++ b/carma-messenger-core/message/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,6 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+# Change the distributionUrl to the following to download the gradle version for source builds
+#distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=/home/carma/gradle-4.10.2-all.zip

--- a/carma-messenger-core/message/gradle/wrapper/gradle-wrapper.properties
+++ b/carma-messenger-core/message/gradle/wrapper/gradle-wrapper.properties
@@ -5,4 +5,4 @@
 #zipStorePath=wrapper/dists
 # Change the distributionUrl to the following to download the gradle version for source builds
 #distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
-distributionUrl=/home/carma/.gradle/wrapper/dists/gradle-4.10.2-bin/cghg6c4gf4vkiutgsab8yrnwv/gradle-4.10.2-bin.zip
+distributionUrl=file\:/home/carma/.gradle/wrapper/dists/gradle-4.10.2-bin/cghg6c4gf4vkiutgsab8yrnwv/gradle-4.10.2-bin.zip

--- a/carma-messenger-core/message/message/build.gradle
+++ b/carma-messenger-core/message/message/build.gradle
@@ -37,7 +37,6 @@ dependencies {
   /* An external maven artifact dependency */
   compile 'org.ros.rosjava_core:rosjava:[0.3,0.4)'
   compile 'org.ros.rosjava_messages:cav_msgs:1.3.0'
-  compile 'org.ros.rosjava_messages:cav_srvs:1.2.1'
   compile 'org.ros.rosjava_messages:j2735_msgs:1.2.1'
   compile 'gov.dot.fhwa.saxton.carma:rosjava_utils:1.0.0'
   

--- a/carma-messenger-core/message/package.xml
+++ b/carma-messenger-core/message/package.xml
@@ -29,7 +29,6 @@
   <depend>genjava</depend>
   <depend>rosjava_messages</depend>
   <depend>cav_msgs</depend>
-  <depend>cav_srvs</depend>
   <depend>j2735_msgs</depend>
   <depend>rostest</depend>
   <depend>rospy</depend>

--- a/carma-messenger-core/rosjava_utils/CMakeLists.txt
+++ b/carma-messenger-core/rosjava_utils/CMakeLists.txt
@@ -29,7 +29,6 @@ find_package(catkin REQUIRED
 	rosjava_build_tools
         rosjava_messages
         cav_msgs
-        cav_srvs
         j2735_msgs
 )
 
@@ -44,7 +43,7 @@ catkin_rosjava_setup(install publish)
 add_dependencies(gradle-${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 
 catkin_package(
-  CATKIN_DEPENDS rosjava_build_tools rosjava_messages cav_msgs cav_srvs j2735_msgs
+  CATKIN_DEPENDS rosjava_build_tools rosjava_messages cav_msgs j2735_msgs
 )
 
 ##############################################################################

--- a/carma-messenger-core/rosjava_utils/gradle/wrapper/gradle-wrapper.properties
+++ b/carma-messenger-core/rosjava_utils/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,8 @@
 #Mon Aug 21 17:10:50 EDT 2017
-#distributionBase=GRADLE_USER_HOME
-#distributionPath=wrapper/dists
-#zipStoreBase=GRADLE_USER_HOME
-#zipStorePath=wrapper/dists
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
 # Change the distributionUrl to the following to download the gradle version for source builds
 #distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
 distributionUrl=file\:/home/carma/.gradle/wrapper/dists/gradle-4.10.2-bin/cghg6c4gf4vkiutgsab8yrnwv/gradle-4.10.2-bin.zip

--- a/carma-messenger-core/rosjava_utils/gradle/wrapper/gradle-wrapper.properties
+++ b/carma-messenger-core/rosjava_utils/gradle/wrapper/gradle-wrapper.properties
@@ -4,5 +4,5 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 # Change the distributionUrl to the following to download the gradle version for source builds
-#distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
-distributionUrl=file\:/home/carma/.gradle/wrapper/dists/gradle-4.10.2-bin/cghg6c4gf4vkiutgsab8yrnwv/gradle-4.10.2-bin.zip
+#distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip
+distributionUrl=file\:/home/carma/.gradle/wrapper/dists/gradle-2.14.1-bin/gradle-2.14.1-bin.zip

--- a/carma-messenger-core/rosjava_utils/gradle/wrapper/gradle-wrapper.properties
+++ b/carma-messenger-core/rosjava_utils/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,6 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-2.14.1-all.zip
+# Change the distributionUrl to the following to download the gradle version for source builds
+#distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=/home/carma/gradle-4.10.2-all.zip

--- a/carma-messenger-core/rosjava_utils/gradle/wrapper/gradle-wrapper.properties
+++ b/carma-messenger-core/rosjava_utils/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,8 @@
 #Mon Aug 21 17:10:50 EDT 2017
-distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
-zipStorePath=wrapper/dists
+#distributionBase=GRADLE_USER_HOME
+#distributionPath=wrapper/dists
+#zipStoreBase=GRADLE_USER_HOME
+#zipStorePath=wrapper/dists
 # Change the distributionUrl to the following to download the gradle version for source builds
 #distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
-distributionUrl=/home/carma/gradle-4.10.2-all.zip
+distributionUrl=/home/carma/.gradle/wrapper/dists/gradle-4.10.2-bin/cghg6c4gf4vkiutgsab8yrnwv/gradle-4.10.2-bin.zip

--- a/carma-messenger-core/rosjava_utils/gradle/wrapper/gradle-wrapper.properties
+++ b/carma-messenger-core/rosjava_utils/gradle/wrapper/gradle-wrapper.properties
@@ -5,4 +5,4 @@
 #zipStorePath=wrapper/dists
 # Change the distributionUrl to the following to download the gradle version for source builds
 #distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
-distributionUrl=/home/carma/.gradle/wrapper/dists/gradle-4.10.2-bin/cghg6c4gf4vkiutgsab8yrnwv/gradle-4.10.2-bin.zip
+distributionUrl=file\:/home/carma/.gradle/wrapper/dists/gradle-4.10.2-bin/cghg6c4gf4vkiutgsab8yrnwv/gradle-4.10.2-bin.zip

--- a/carma-messenger-core/rosjava_utils/package.xml
+++ b/carma-messenger-core/rosjava_utils/package.xml
@@ -29,7 +29,6 @@
   <depend>genjava</depend>
   <depend>rosjava_messages</depend>
   <depend>cav_msgs</depend>
-  <depend>cav_srvs</depend>
   <depend>j2735_msgs</depend>
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR improves build stability in locations with poor internet be removing the unused cav_srvs dependency and targeting the gradle files located in carma-base instead of downloading them at build time. 
<!--- Describe your changes in detail -->

## Related Issue
Developed to support #908
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Make building more feasible at ATEF
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Building using wifi in the red truck
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.