### PR TITLE
hotfix 1.0.2

### DIFF
--- a/carma-messenger-config/chevrolet_tahoe_2018/docker-compose-background.yml
+++ b/carma-messenger-config/chevrolet_tahoe_2018/docker-compose-background.yml
@@ -17,7 +17,7 @@ version: '2'
 
 services:
   carma-messenger-ui:
-    image: usdotfhwastol/carma-messenger-ui:1.0.1
+    image: usdotfhwastol/carma-messenger-ui:1.0.2
     network_mode: host
     container_name: carma-messenger-ui
     environment:

--- a/carma-messenger-config/chevrolet_tahoe_2018/docker-compose.yml
+++ b/carma-messenger-config/chevrolet_tahoe_2018/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     command: roscore
 
   messenger:
-    image: usdotfhwastol/carma-messenger-core:1.0.1
+    image: usdotfhwastol/carma-messenger-core:1.0.2
     network_mode: host
     container_name: carma-messenger-core
     volumes_from:

--- a/carma-messenger-config/chevrolet_tahoe_2018/hooks/build
+++ b/carma-messenger-config/chevrolet_tahoe_2018/hooks/build
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "Building $IMAGE_NAME"
+
+docker build --no-cache -t $IMAGE_NAME \
+    --build-arg VERSION="$DOCKER_TAG" \
+    --build-arg VCS_REF=`git rev-parse --short HEAD` \
+    --build-arg BUILD_DATE=`date -u +”%Y-%m-%dT%H:%M:%SZ”` .
+    

--- a/carma-messenger-config/chevrolet_tahoe_2018/hooks/pre_build
+++ b/carma-messenger-config/chevrolet_tahoe_2018/hooks/pre_build
@@ -4,12 +4,12 @@ if [[ "$SOURCE_BRANCH" = "develop" ]]; then
     # add -t flag to checkout.bash and update image dependencies
     sed -i "s|/checkout.bash|/checkout.bash -d|g; s|usdotfhwastol|usdotfhwastoldev|g; s|:[0-9]*\.[0-9]*\.[0-9]*|:develop|g" \
         Dockerfile
-elif [[ "$SOURCE_BRANCH" =~ ^release/.*$ ]]; then
+elif [[ "$SOURCE_BRANCH" =~ ^release/.*$ ]] || [[ "$SOURCE_BRANCH" =~ ^hotfix/.*$ ]]; then
     # swap checkout branch in checkout.bash to release branch
-    sed -i "s|usdotfhwastol|usdotfhwastolcandidate|g; s|:[0-9]*\.[0-9]*\.[0-9]*|:candidate|g; s|CARMA[a-zA-Z]*_[0-9]*\.[0-9]*\.[0-9]*|candidate|g; s|carma-[a-zA-Z]*-[0-9]*\.[0-9]*\.[0-9]*|candidate|g" \
+    sed -i "s|usdotfhwastol/|usdotfhwastolcandidate/|g; s|:[0-9]*\.[0-9]*\.[0-9]*|:candidate|g; s|CARMA[a-zA-Z]*_[0-9]*\.[0-9]*\.[0-9]*|candidate|g; s|carma-[a-zA-Z]*-[0-9]*\.[0-9]*\.[0-9]*|candidate|g" \
         Dockerfile
-    sed -i "s|usdotfhwastol|usdotfhwastolcandidate|g; s|:[0-9]*\.[0-9]*\.[0-9]*|:candidate|g; s|CARMA[a-zA-Z]*_[0-9]*\.[0-9]*\.[0-9]*|candidate|g; s|carma-[a-zA-Z]*-[0-9]*\.[0-9]*\.[0-9]*|candidate|g" \
+    sed -i "s|usdotfhwastol/|usdotfhwastolcandidate/|g; s|:[0-9]*\.[0-9]*\.[0-9]*|:candidate|g; s|CARMA[a-zA-Z]*_[0-9]*\.[0-9]*\.[0-9]*|candidate|g; s|carma-[a-zA-Z]*-[0-9]*\.[0-9]*\.[0-9]*|candidate|g" \
         docker-compose.yml
-    sed -i "s|usdotfhwastol|usdotfhwastolcandidate|g; s|:[0-9]*\.[0-9]*\.[0-9]*|:candidate|g; s|CARMA[a-zA-Z]*_[0-9]*\.[0-9]*\.[0-9]*|candidate|g; s|carma-[a-zA-Z]*-[0-9]*\.[0-9]*\.[0-9]*|candidate|g" \
+    sed -i "s|usdotfhwastol/|usdotfhwastolcandidate/|g; s|:[0-9]*\.[0-9]*\.[0-9]*|:candidate|g; s|CARMA[a-zA-Z]*_[0-9]*\.[0-9]*\.[0-9]*|candidate|g; s|carma-[a-zA-Z]*-[0-9]*\.[0-9]*\.[0-9]*|candidate|g" \
         docker-compose-background.yml
 fi

--- a/carma-messenger-config/development/docker-compose-background.yml
+++ b/carma-messenger-config/development/docker-compose-background.yml
@@ -17,7 +17,7 @@ version: '2'
 
 services:
   carma-messenger-ui:
-    image: usdotfhwastol/carma-messenger-ui:1.0.1
+    image: usdotfhwastol/carma-messenger-ui:1.0.2
     network_mode: host
     container_name: carma-messenger-ui
     volumes_from: 

--- a/carma-messenger-config/development/docker-compose.yml
+++ b/carma-messenger-config/development/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     command: roscore
 
   messenger:
-    image: usdotfhwastol/carma-messenger-core:1.0.1
+    image: usdotfhwastol/carma-messenger-core:1.0.2
     network_mode: host
     container_name: carma-messenger-core
     volumes_from:

--- a/carma-messenger-config/development/hooks/build
+++ b/carma-messenger-config/development/hooks/build
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "Building $IMAGE_NAME"
+
+docker build --no-cache -t $IMAGE_NAME \
+    --build-arg VERSION="$DOCKER_TAG" \
+    --build-arg VCS_REF=`git rev-parse --short HEAD` \
+    --build-arg BUILD_DATE=`date -u +”%Y-%m-%dT%H:%M:%SZ”` .
+    

--- a/carma-messenger-config/development/hooks/pre_build
+++ b/carma-messenger-config/development/hooks/pre_build
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [[ "$SOURCE_BRANCH" = "develop" ]]; then
+    # add -t flag to checkout.bash and update image dependencies
+    sed -i "s|/checkout.bash|/checkout.bash -d|g; s|usdotfhwastol|usdotfhwastoldev|g; s|:[0-9]*\.[0-9]*\.[0-9]*|:develop|g" \
+        Dockerfile
+elif [[ "$SOURCE_BRANCH" =~ ^release/.*$ ]] || [[ "$SOURCE_BRANCH" =~ ^hotfix/.*$ ]]; then
+    # swap checkout branch in checkout.bash to release branch
+    sed -i "s|usdotfhwastoldev/|usdotfhwastolcandidate/|g; s|usdotfhwastol/|usdotfhwastolcandidate/|g; s|:[0-9]*\.[0-9]*\.[0-9]*|:candidate|g; s|CARMA[a-zA-Z]*_[0-9]*\.[0-9]*\.[0-9]*|candidate|g; s|carma-[a-zA-Z]*-[0-9]*\.[0-9]*\.[0-9]*|candidate|g" \
+        Dockerfile
+    sed -i "s|usdotfhwastoldev/|usdotfhwastolcandidate/|g; s|usdotfhwastol/|usdotfhwastolcandidate/|g; s|:[0-9]*\.[0-9]*\.[0-9]*|:candidate|g; s|CARMA[a-zA-Z]*_[0-9]*\.[0-9]*\.[0-9]*|candidate|g; s|carma-[a-zA-Z]*-[0-9]*\.[0-9]*\.[0-9]*|candidate|g" \
+        docker-compose.yml
+    sed -i "s|usdotfhwastoldev/|usdotfhwastolcandidate/|g; s|usdotfhwastol/|usdotfhwastolcandidate/|g; s|:[0-9]*\.[0-9]*\.[0-9]*|:candidate|g; s|CARMA[a-zA-Z]*_[0-9]*\.[0-9]*\.[0-9]*|candidate|g; s|carma-[a-zA-Z]*-[0-9]*\.[0-9]*\.[0-9]*|candidate|g" \
+        docker-compose-background.yml
+fi


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This hotfix release adds docker build hooks to enable metadata in carma-messenger-config images.
<!--- Describe your changes in detail -->

## Related Issue
[#948](https://github.com/usdot-fhwa-stol/carma-platform/issues/948)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Needed in order to display version number for carma-messenger-config
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Employs the same build hook used by all other repos, which is successfully populating images with metadata
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.