### PR TITLE
Dockerfile updates to enable carma-messenger-core Vanden Plas candidate image build

### DIFF
--- a/carma-messenger-config/chevrolet_tahoe_2018/docker-compose-background.yml
+++ b/carma-messenger-config/chevrolet_tahoe_2018/docker-compose-background.yml
@@ -17,7 +17,7 @@ version: '2'
 
 services:
   carma-messenger-ui:
-    image: usdotfhwastoldev/carma-messenger-ui:develop
+    image: usdotfhwastolcandidate/carma-messenger-ui:vanden-plas
     network_mode: host
     container_name: carma-messenger-ui
     environment:

--- a/carma-messenger-config/chevrolet_tahoe_2018/docker-compose.yml
+++ b/carma-messenger-config/chevrolet_tahoe_2018/docker-compose.yml
@@ -17,7 +17,7 @@ version: '2'
 
 services:
   roscore:
-    image: usdotfhwastoldev/carma-base:develop
+    image: usdotfhwastolcandidate/carma-base:vanden-plas
     network_mode: host
     container_name: roscore
     volumes_from:
@@ -30,7 +30,7 @@ services:
     command: roscore
 
   messenger:
-    image: usdotfhwastoldev/carma-messenger-core:develop
+    image: usdotfhwastolcandidate/carma-messenger-core:vanden-plas
     network_mode: host
     container_name: carma-messenger-core
     volumes_from:
@@ -43,7 +43,7 @@ services:
     command: wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/carma-messenger-docker.launch
 
   cohda_dsrc_driver:
-    image: usdotfhwastoldev/carma-cohda-dsrc-driver:develop
+    image: usdotfhwastolcandidate/carma-cohda-dsrc-driver:vanden-plas
     container_name: carma-cohda-dsrc-driver
     network_mode: host
     volumes_from:

--- a/carma-messenger-config/development/docker-compose-background.yml
+++ b/carma-messenger-config/development/docker-compose-background.yml
@@ -17,7 +17,7 @@ version: '2'
 
 services:
   carma-messenger-ui:
-    image: usdotfhwastoldev/carma-messenger-ui:develop
+    image: usdotfhwastolcandidate/carma-messenger-ui:vanden-plas
     network_mode: host
     container_name: carma-messenger-ui
     volumes_from: 

--- a/carma-messenger-config/development/docker-compose.yml
+++ b/carma-messenger-config/development/docker-compose.yml
@@ -17,7 +17,7 @@ version: '2'
 
 services:
   roscore:
-    image: usdotfhwastoldev/carma-base:develop
+    image: usdotfhwastolcandidate/carma-base:vanden-plas
     network_mode: host
     container_name: roscore
     volumes_from:
@@ -28,7 +28,7 @@ services:
     command: roscore
 
   messenger:
-    image: usdotfhwastoldev/carma-messenger-core:develop
+    image: usdotfhwastolcandidate/carma-messenger-core:vanden-plas
     network_mode: host
     container_name: carma-messenger-core
     volumes_from:
@@ -39,7 +39,7 @@ services:
     command: wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/carma-messenger-docker.launch
 
   cohda_dsrc_driver:
-    image: usdotfhwastoldev/carma-cohda-dsrc-driver:develop
+    image: usdotfhwastolcandidate/carma-cohda-dsrc-driver:vanden-plas
     container_name: carma-cohda-dsrc-driver
     network_mode: host
     volumes_from:

--- a/carma-messenger-core/Dockerfile
+++ b/carma-messenger-core/Dockerfile
@@ -12,7 +12,7 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 
-FROM usdotfhwastoldev/carma-base:develop as setup
+FROM usdotfhwastolcandidate/carma-base:vanden-plas as setup
 
 RUN mkdir ~/src
 COPY --chown=carma . /home/carma/src/
@@ -21,7 +21,7 @@ RUN ~/src/docker/checkout.bash
 
 RUN ~/src/docker/install.sh
 
-FROM usdotfhwastoldev/carma-base:develop
+FROM usdotfhwastolcandidate/carma-base:vanden-plas
 
 ARG BUILD_DATE="NULL"
 ARG VERSION="NULL"


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
Dockerfile updates for carma-messenger-core to enable Vanden Plas candidate image to be built using the release/vanden-plas branch.

## Description
Updated the carma-messenger-core Dockerfile to reference usdotfhwastolcandidate/carma-base:vanden-plas as the base image in order to build the Vanden Plas candidate image for carma-messenger-core using the release/vanden-plas branch.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The original carma-messenger-core Dockerfile in the release/vanden-plas branch did not reference the correct base image.

## How Has This Been Tested?
A carma-messenger-core docker image was successfully built with these changes.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.