### PR TITLE
fixed dow bit-wise encoding/decoding

### DIFF
--- a/carma-messenger-core/cpp_message/src/cpp_message.cpp
+++ b/carma-messenger-core/cpp_message/src/cpp_message.cpp
@@ -535,9 +535,8 @@ namespace cpp_message
     {
         j2735_msgs::DayOfWeek output;
         
-        size_t dow_size= message.size;
         uint8_t tmp_binary=0;
-        for (auto i = 0; i < dow_size; i++) // size is 1 as 8 bits are sufficient for bit-wise encoding of 7 days 
+        if (message.size > 0) // size is default 1 as 8 bits are sufficient for bit-wise encoding of 7 days 
         {
             tmp_binary = message.buf[0] >> 1; // 7 days in a week, while there are 8 entries
             for (int j = output.dow.size() - 1; j >= 0; j --) // NOTE: Do not use size_t for i type here as -- with > 0 will result in overflow

--- a/carma-messenger-core/cpp_message/src/cpp_message.cpp
+++ b/carma-messenger-core/cpp_message/src/cpp_message.cpp
@@ -536,9 +536,15 @@ namespace cpp_message
         j2735_msgs::DayOfWeek output;
         
         size_t dow_size= message.size;
-        for (auto i = 0; i < dow_size; i++)
+        uint8_t tmp_binary=0;
+        for (auto i = 0; i < dow_size; i++) // size is 1 as 8 bits are sufficient for bit-wise encoding of 7 days 
         {
-            output.dow[i] = message.buf[i];
+            tmp_binary = message.buf[0] >> 1; // 7 days in a week, while there are 8 entries
+            for (int j = output.dow.size() - 1; j >= 0; j --) // NOTE: Do not use size_t for i type here as -- with > 0 will result in overflow
+            {
+                output.dow[j] = tmp_binary % 2;
+                tmp_binary = tmp_binary >> 1;
+            }
         }
         return output;
     } 
@@ -1367,11 +1373,12 @@ namespace cpp_message
         output = (DSRC_DayOfWeek_t*) calloc(1, sizeof(DSRC_DayOfWeek_t));
         
         uint8_t* dow_val;
-        dow_val = (uint8_t*)calloc(msg.dow.size(), sizeof(uint8_t));
+        dow_val = (uint8_t*)calloc(1, sizeof(uint8_t)); // 8 bits are sufficient for bit-wise encoding for 7 days
+        uint8_t tmp_binary;
         for (auto i = 0; i < msg.dow.size(); i++)
         {
-            dow_val[i] = msg.dow[i];
-
+            tmp_binary |= msg.dow[i];
+            tmp_binary = tmp_binary << 1;
         }
         output->buf = dow_val;
         output->size = msg.dow.size();

--- a/carma-messenger-core/cpp_message/src/cpp_message.cpp
+++ b/carma-messenger-core/cpp_message/src/cpp_message.cpp
@@ -909,7 +909,7 @@ namespace cpp_message
             // encode updated
             // recover an 8-bit array from a long value 
             uint8_t updated_val[8] = {0};
-            for(auto k = 7; k >= 0; k--) {
+            for(int k = 7; k >= 0; k--) {
                 updated_val[7 - k] = msg_v01.updated >> (k * 8);
             }
             output_v01->updated.buf = updated_val;
@@ -996,7 +996,7 @@ namespace cpp_message
                 msg_schedule = msg_params.schedule;
                 // 8-bit array from long int for "start"
                 uint8_t start_val[8] = {0};
-                for(auto k = 7; k >= 0; k--) {
+                for(int k = 7; k >= 0; k--) {
                     start_val[7 - k] = msg_schedule.start >> (k * 8);
                 }
                 EpochMins_t* start_p;
@@ -1009,7 +1009,7 @@ namespace cpp_message
                 if (msg_schedule.end_exists)
                 {
                     uint8_t end_val[8] = {0};
-                    for(auto k = 7; k >= 0; k--) {
+                    for(int k = 7; k >= 0; k--) {
                         end_val[7 - k] = msg_schedule.end >> (k * 8);
                     }
                     EpochMins_t* end_p;
@@ -1085,7 +1085,7 @@ namespace cpp_message
                 output_geometry->datum.size = datum_size;
                 
                 uint8_t reftime_val[8] = {0};
-                for(auto k = 7; k >= 0; k--) {
+                for(int k = 7; k >= 0; k--) {
                     reftime_val[7 - k] = msg_geometry.reftime >> (k * 8);
                 }
 
@@ -1504,7 +1504,7 @@ namespace cpp_message
                 bounds_p->offsets = *offsets;
                 //convert a long value to an 8-bit array of length 8
                 uint8_t oldest_val[8];
-                for(auto k = 7; k >= 0; k--) {
+                for(int k = 7; k >= 0; k--) {
                     oldest_val[7-k] = request_msg.tcrV01.bounds[i].oldest >> (k * 8);
                 }
                 bounds_p->oldest.size = 8;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Day of week in TCM is encoded as bits. For example 254 int is 11111110 in binary which correspond to every day being available (last 0 is not used as there are 7 days and 8 bits). This PR makes sure it conforms to that.

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1303
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Found during RWM testing.
## How Has This Been Tested?
Local integration tested.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.