### PR TITLE
Update ROS Noetic branch to C++14

### DIFF
--- a/carma-messenger-core/cpp_message/CMakeLists.txt
+++ b/carma-messenger-core/cpp_message/CMakeLists.txt
@@ -16,8 +16,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cpp_message)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++17)
+## Compile as C++14, supported in ROS Noetic and newer
+add_compile_options(-std=c++14)
 set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 

--- a/carma-messenger-core/j2735_convertor/CMakeLists.txt
+++ b/carma-messenger-core/j2735_convertor/CMakeLists.txt
@@ -16,8 +16,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(j2735_convertor)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+## Compile as C++14, supported in ROS Noetic and newer
+add_compile_options(-std=c++14)
 set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 

--- a/carma-messenger-core/traffic_incident/CMakeLists.txt
+++ b/carma-messenger-core/traffic_incident/CMakeLists.txt
@@ -16,7 +16,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(traffic_incident)
 
-## Compile as C++14, supported in ROS Kinetic and newer
+## Compile as C++14, supported in ROS Noetic and newer
 add_compile_options(-std=c++14)
 
 ## Find catkin macros and libraries

--- a/carma-messenger-core/truck_inspection_plugin/CMakeLists.txt
+++ b/carma-messenger-core/truck_inspection_plugin/CMakeLists.txt
@@ -17,8 +17,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(truck_inspection_plugin)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+## Compile as C++14, supported in ROS Noetic and newer
+add_compile_options(-std=c++14)
 set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 


### PR DESCRIPTION
# PR Details
## Description

Update the CMakeLists.txt files to specify c++14 instead of C++11. 

## Motivation and Context

Using C++ 14 to compile the CARMA source code on Ubuntu 20.04.

## How Has This Been Tested?

Full build and checking the output logs for C++ 14 usage.

## Checklist:
- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
