### PR TITLE
Update to package format 3 and run xmllint

### DIFF
--- a/carma-messenger-core/carma-messenger/CMakeLists.txt
+++ b/carma-messenger-core/carma-messenger/CMakeLists.txt
@@ -14,7 +14,7 @@
 # the License.
 
 cmake_minimum_required(VERSION 2.8.3)
-project(carma-messenger)
+project(carma_messenger)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/carma-messenger-core/carma-messenger/package.xml
+++ b/carma-messenger-core/carma-messenger/package.xml
@@ -15,12 +15,10 @@
   the License.
 -->
 <package format="3">
-  <name>carma-messenger</name>
+  <name>carma_messenger</name>
   <version>1.0.0</version>
   <description>Meta-package for launching a full carma-messenger instance</description>
-
   <maintainer email="carma@todo.todo">carma</maintainer>
-
   <license>Apache 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>


### PR DESCRIPTION
Update remaining packages that had package format version 2 to version 3 and address any xmllint issues when testing against the package format v3 schema (typically just reordering items).

For this package, the "-" character isn't valid in package names. 