### PR TITLE
Changed cav_msgs/MobilityPlanType back to cav_msgs/PlanType

### DIFF
--- a/carma-messenger-core/cpp_message/src/MobilityResponse_Message.cpp
+++ b/carma-messenger-core/cpp_message/src/MobilityResponse_Message.cpp
@@ -121,7 +121,7 @@ namespace cpp_message
 
             //get the mobility plan choice
             MobilityPlanType_t planType_choice = message->value.choice.TestMessage01.body.planType;
-            output.plan_type.choice = planType_choice;
+            output.plan_type.type = planType_choice;
             
             //get the mobility reason choice
             MobilityReason_t reason_choice = *message->value.choice.TestMessage01.body.reason;
@@ -249,7 +249,7 @@ namespace cpp_message
         //get isAccepted
         message->value.choice.TestMessage01.body.isAccepted=plainMessage.is_accepted;
         //get plantype
-        message->value.choice.TestMessage01.body.planType = plainMessage.plan_type.choice;
+        message->value.choice.TestMessage01.body.planType = plainMessage.plan_type.type;
         //get reason
         long reason_choice = plainMessage.reason.choice;
         message->value.choice.TestMessage01.body.reason = &reason_choice;

--- a/carma-messenger-core/cpp_message/test/test_MobilityResponse.cpp
+++ b/carma-messenger-core/cpp_message/test/test_MobilityResponse.cpp
@@ -41,7 +41,7 @@ TEST(MobilityResponseMessageTest, testDecodeMobilityResponseMsg)
         }
         else EXPECT_TRUE(false);
         EXPECT_EQ(to_read.is_accepted, 1);
-        EXPECT_EQ(to_read.plan_type.choice, 7);
+        EXPECT_EQ(to_read.plan_type.type, 7);
         EXPECT_EQ(to_read.reason.choice, 3);
         EXPECT_EQ(to_read.repeat.choice, 1);
     }
@@ -62,7 +62,7 @@ TEST(MobilityResponseMessageTest, testEncodeMobilityResponseMsg)
     message.m_header=header;
     message.urgency=50;
     message.is_accepted = 1;
-    message.plan_type.choice = 7;
+    message.plan_type.type = 7;
     message.reason.choice = 3;
     message.repeat.choice = 1;
     auto res = worker.encode_mobility_response_message(message);
@@ -95,7 +95,7 @@ TEST(MobilityResponseMessageTest, testEncodeMobilityResponseMsg_base_case)
     message.m_header=header;
     message.urgency=0;
     message.is_accepted=0;
-    message.plan_type.choice = 0;
+    message.plan_type.type = 0;
     message.reason.choice = 0;
     message.repeat.choice = 0;
     auto res = worker.encode_mobility_response_message(message);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
When adding fields to the MobilityResponse message, it was updated to use the new MobilityPlanType message, instead of the old PlanType message. This is unintended and causes a message mismatch.

The solution is to remove the new MobilityPlanType message, and instead add its new enum fields to the PlanType message, also updating the cpp_message file and relevant unit tests. These changes for both cav_msgs and carma_v2x_msgs.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/usdot-fhwa-stol/carma-platform/issues/1775

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.