### PR TITLE
Fix/tcm encoder memory

### DIFF
--- a/carma-messenger-core/cpp_message/src/cpp_message.cpp
+++ b/carma-messenger-core/cpp_message/src/cpp_message.cpp
@@ -784,8 +784,17 @@ namespace cpp_message
         }
         output.datum = datum;
 
+        // // convert reftime
+        // // uint64_t reftime = 0;
+        // uint64_t* reftime = new uint64_t;
+        // for (auto i=0; i<message.reftime.size; i++){
+        //     *reftime |= message.reftime.buf[i];
+        //     //reftime |= message.reftime.buf[i];
+        //     if (i != message.reftime.size - 1) *reftime = *reftime << 8;
+        // }
+        // output.reftime = *reftime;
+        
         // convert reftime
-        std:: cout << std::endl;
         uint64_t reftime = 0;
         for (auto i=0; i<message.reftime.size; i++){
             reftime |= message.reftime.buf[i];
@@ -1021,30 +1030,107 @@ namespace cpp_message
                     output_package->label = label_p;
                 }
 
+
+                // // nodes
+                // auto nodes_len = msg_geometry.nodes.size();
+                // TrafficControlGeometry::TrafficControlGeometry__nodes* nodes_list;
+                // nodes_list = (TrafficControlGeometry::TrafficControlGeometry__nodes*) calloc(1, sizeof(TrafficControlGeometry::TrafficControlGeometry__nodes));
+                
+                // for (auto i = 0; i < nodes_len; i ++)
+                // {
+                //     //=============== TCMV01 - GEOMETRY - NODE START ===========================
+                //     PathNode_t* output_node;
+                //     output_node = (PathNode_t*) calloc(1, sizeof(PathNode_t));
+                //     j2735_v2x_msgs::msg::PathNode msg_node;
+                //     msg_node = msg_geometry.nodes[i];
+                //     output_node->x = msg_node.x;
+                //     output_node->y = msg_node.y;
+                //     // optional fields
+                //     if (msg_node.z_exists) 
+                //     {
+                //         long z_temp = msg_node.z;
+                //         output_node->z = &z_temp;
+                //     }
+
+                //     if (msg_node.width_exists) 
+                //     {
+                //         long width_temp = msg_node.width;
+                //         output_node->width = &width_temp;
+                //     }
+                //     //================== TCMV01 - GEOMETRY - NODE END =============================
+                //     asn_sequence_add(&nodes_list->list, output_node);
+                // }
+                // output_geometry->nodes = *nodes_list;
+
+
                 // convert tcids from list of Id128b
                 // tcid is array of ids, each of which is a 16-bit pointer to an array of ids
                 auto tcids_len = msg_package.tcids.size();
                 TrafficControlPackage::TrafficControlPackage__tcids* tcids;
                 tcids = (TrafficControlPackage::TrafficControlPackage__tcids*) calloc(1, sizeof(TrafficControlPackage::TrafficControlPackage__tcids));
+                
+                // for (auto j = 0; j < tcids_len; j++)
+                // {
+                //     std::cout << "-1tcids " << j << ": [";
+                //     for (auto k = 0; k < 16; k++)
+                //     {
+                //         std::cout << +msg_package.tcids[j].id[k] << ", ";
+                //     }
+                //     std::cout << "\b\b]" << std::endl;
+                // }
+
                 for (auto i = 0; i < tcids_len; i++)
                 {
-                    Id128b_t* output_128b;
-                    output_128b = (Id128b_t*) calloc(1, sizeof(Id128b_t));
+                    Id128b_t* output_128b = new Id128b_t;
+                    // output_128b = (Id128b_t*) calloc(1, sizeof(Id128b_t));
                     j2735_v2x_msgs::msg::Id128b msg_128b;
                     msg_128b = msg_package.tcids[i];
                     
                     // Type uint8[16]
-                    uint8_t val[16] = {0};
-                    for(auto i = 0; i < msg_128b.id.size(); i++)
+                    uint8_t* val;
+                    val = (uint8_t*) calloc(16, sizeof(uint8_t));
+                    // uint8_t val[16] = {0};// 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115};
+                    for(auto t = 0; t < msg_128b.id.size(); t++)
                     {
-                        val[i] = msg_128b.id[i];
+                        val[t] = msg_128b.id[t];
                     }
                     output_128b->buf = val;
                     output_128b->size = msg_128b.id.size();
+                    
                     asn_sequence_add(&tcids->list, output_128b);
                 }
                 
                 output_package->tcids = *tcids;
+
+                // for (auto j = 0; j < tcids_len; j++)
+                // {
+                //     std::cout << "-1tcids " << j << ": [";
+                //     for (auto k = 0; k < 16; k++)
+                //     {
+                //         std::cout << +msg_package.tcids[j].id[k] << ", ";
+                //     }
+                //     std::cout << "\b\b]" << std::endl;
+                // }
+
+                // for (auto j = 0; j < 2; j++)
+                // {
+                //     std::cout << "+1tcids " << j << ": [";
+                //     for (auto k = 0; k < 16; k++)
+                //     {
+                //         std::cout << +tcids->list.array[j]->buf[k] << ", ";
+                //     }
+                //     std::cout << "\b\b]" << std::endl;
+                // }
+
+                // for (auto j = 0; j < 2; j++)
+                // {
+                //     std::cout << "tcids " << j << ": [";
+                //     for (auto i = 0; i < 16; i++)
+                //     {
+                //         std::cout << +tcids->list.array[j]->buf[i] << ", ";
+                //     }
+                //     std::cout << "\b\b]" << std::endl;
+                // }
                 
                 // ================= PACKAGE END ==========================
                 output_v01->package = output_package;
@@ -1075,7 +1161,8 @@ namespace cpp_message
                 j2735_v2x_msgs::msg::TrafficControlSchedule msg_schedule;
                 msg_schedule = msg_params.schedule;
                 // 8-bit array from long int for "start"
-                uint8_t start_val[8] = {0};
+                uint8_t* start_val;
+                start_val = (uint8_t*) calloc(8, sizeof(uint8_t));
                 for(int k = 7; k >= 0; k--) {
                     start_val[7 - k] = msg_schedule.start >> (k * 8);
                 }
@@ -1088,7 +1175,9 @@ namespace cpp_message
                 // long int from 8-bit array for "end" (optional)
                 if (msg_schedule.end_exists)
                 {
-                    uint8_t end_val[8] = {0};
+                    uint8_t* end_val;
+                    end_val = (uint8_t*) calloc(8, sizeof(uint8_t));
+                    // uint8_t end_val[8] = {0};
                     for(int k = 7; k >= 0; k--) {
                         end_val[7 - k] = msg_schedule.end >> (k * 8);
                     }
@@ -1164,7 +1253,9 @@ namespace cpp_message
                 output_geometry->datum.buf = datum_content;
                 output_geometry->datum.size = datum_size;
                 
-                uint8_t reftime_val[8] = {0};
+                uint8_t* reftime_val;
+                reftime_val = (uint8_t*) calloc(8, sizeof(uint8_t));
+                // uint8_t reftime_val[8] = {0};
                 for(int k = 7; k >= 0; k--) {
                     reftime_val[7 - k] = msg_geometry.reftime >> (k * 8);
                 }
@@ -1202,16 +1293,20 @@ namespace cpp_message
                     output_node->x = msg_node.x;
                     output_node->y = msg_node.y;
                     // optional fields
+                    // NOTE: When a variable is declared in a loop like this, it will be overwritten the next time the loop is executed.
+                    // In this case, x and y are fine but z and width will be assigned to each as the value of the last node. 
                     if (msg_node.z_exists) 
                     {
-                        long z_temp = msg_node.z;
-                        output_node->z = &z_temp;
+                        long* z_temp = new long;
+                        *z_temp = msg_node.z;
+                        output_node->z = z_temp;
                     }
 
                     if (msg_node.width_exists) 
                     {
-                        long width_temp = msg_node.width;
-                        output_node->width = &width_temp;
+                        long* width_temp = new long;
+                        *width_temp = msg_node.width;
+                        output_node->width = width_temp;
                     }
                     //================== TCMV01 - GEOMETRY - NODE END =============================
                     asn_sequence_add(&nodes_list->list, output_node);
@@ -1244,7 +1339,8 @@ namespace cpp_message
         auto array_length = (ec.encoded+7) / 8;
         std::vector<uint8_t> b_array(array_length);
         for(auto i = 0; i < array_length; i++) b_array[i] = buffer[i];
-        // for(auto i = 0; i < array_length; i++) std::cout<< (int)b_array[i]<< ", ";
+        for(auto i = 0; i < array_length; i++) std::cout<< (int)b_array[i]<< ", ";
+        std::cout << "\n";
         return boost::optional<std::vector<uint8_t>>(b_array);
     }
 
@@ -1463,19 +1559,28 @@ namespace cpp_message
     
     DSRC_DayOfWeek_t* Node::encode_day_of_week(const j2735_v2x_msgs::msg::DayOfWeek& msg)
     {
+        // j2735_v2x_msgs day of week:
+        // Array of [0, 1] for each day, with indices specified as an enum. 1 means that that day is active, 0 means inactive
+        // ex: turn on sunday and monday: [0, 0, 0, 0, 0, 1, 1], dow.SUN -> dow[6] -> 1
+
+        // DSRC day of week:
+        // 7-element bit string with a bit for each day,  means that that day is active, 0 means inactive
+        // ex: turn on sunday and monday: 00000110, dow.DSRC_DayOfWeek_sun -> 1
+
         DSRC_DayOfWeek_t* output;
         output = (DSRC_DayOfWeek_t*) calloc(1, sizeof(DSRC_DayOfWeek_t));
         
         uint8_t* dow_val;
-        dow_val = (uint8_t*)calloc(1, sizeof(uint8_t)); // 8 bits are sufficient for bit-wise encoding for 7 days
-        uint8_t tmp_binary;
+        dow_val = (uint8_t*) calloc(1, sizeof(uint8_t)); // 8 bits are sufficient for bit-wise encoding for 7 days
+        // uint8_t tmp_binary = 0;
         for (auto i = 0; i < msg.dow.size(); i++)
         {
-            tmp_binary |= msg.dow[i];
-            tmp_binary = tmp_binary << 1;
+            *dow_val |= msg.dow[i];
+            *dow_val = *dow_val << 1;
         }
         output->buf = dow_val;
-        output->size = msg.dow.size();
+        output->size = 1; // 1 byte
+        output->bits_unused = 1; // uses the first 7 bits, last is unused
 
         return output;
     } 
@@ -1597,7 +1702,8 @@ namespace cpp_message
                 }
                 bounds_p->offsets = *offsets;
                 //convert a long value to an 8-bit array of length 8
-                uint8_t oldest_val[8];
+                uint8_t* oldest_val;
+                oldest_val = (uint8_t*) calloc(8, sizeof(uint8_t));
                 for(int k = 7; k >= 0; k--) {
                     oldest_val[7-k] = request_msg.tcr_v01.bounds[i].oldest >> (k * 8);
                 }

--- a/carma-messenger-core/cpp_message/src/cpp_message.cpp
+++ b/carma-messenger-core/cpp_message/src/cpp_message.cpp
@@ -1009,7 +1009,7 @@ namespace cpp_message
                 {
                     size_t label_size = msg_package.label.size();
                     uint8_t* label_content;
-                    label_content = (uint8_t*) calloc(1, sizeof(uint8_t));
+                    label_content = (uint8_t*) calloc(label_size, sizeof(uint8_t));
                     for(auto i = 0; i < label_size; i++)
                     {
                         label_content[i] = (char)msg_package.label[i];
@@ -1022,15 +1022,16 @@ namespace cpp_message
                 }
 
                 // convert tcids from list of Id128b
+                // tcid is array of ids, each of which is a 16-bit pointer to an array of ids
                 auto tcids_len = msg_package.tcids.size();
                 TrafficControlPackage::TrafficControlPackage__tcids* tcids;
-                tcids = (TrafficControlPackage::TrafficControlPackage__tcids*)calloc(1, sizeof(TrafficControlPackage::TrafficControlPackage__tcids));
+                tcids = (TrafficControlPackage::TrafficControlPackage__tcids*) calloc(1, sizeof(TrafficControlPackage::TrafficControlPackage__tcids));
                 for (auto i = 0; i < tcids_len; i++)
                 {
                     Id128b_t* output_128b;
+                    output_128b = (Id128b_t*) calloc(1, sizeof(Id128b_t));
                     j2735_v2x_msgs::msg::Id128b msg_128b;
                     msg_128b = msg_package.tcids[i];
-                    output_128b = (Id128b_t*) calloc(1, sizeof(Id128b_t));
                     
                     // Type uint8[16]
                     uint8_t val[16] = {0};

--- a/carma-messenger-core/cpp_message/test/test_encode_decode.cpp
+++ b/carma-messenger-core/cpp_message/test/test_encode_decode.cpp
@@ -16,6 +16,8 @@
 
 #include "cpp_message/cpp_message.h"
 #include <gtest/gtest.h>
+#include <rclcpp/rclcpp.hpp>
+#include <carma_ros2_utils/carma_lifecycle_node.hpp>
 
 TEST(CppMessageTest, testDecodeControlMsgPackage)
 {
@@ -243,6 +245,14 @@ TEST(CppMessageTest, testEncodeControlMsg2)
     // TrafficControlGeometry END
     // TrafficControlMessageV01 END
     control_main.tcm_v01 = control;
+
+
+    auto TCM_pub_ = worker->create_publisher<j2735_v2x_msgs::msg::TrafficControlMessage>("test/defined_TCM", 5);
+    TCM_pub_->on_activate();
+    sleep(5);
+    TCM_pub_->publish(control_main);
+    sleep(1);
+
     // TrafficControlMessage END
     auto res = worker->encode_geofence_control(control_main);
     if(res) EXPECT_TRUE(true);
@@ -260,134 +270,137 @@ TEST(CppMessageTest, testEncodeControlMsg2)
         EXPECT_TRUE(false);
     }
     j2735_v2x_msgs::msg::TrafficControlMessage result = res_decoded.get();
+    sleep(1);
+    TCM_pub_->publish(result);
+    sleep(1);
     EXPECT_EQ(result.tcm_v01.id.id, control_main.tcm_v01.id.id);
     EXPECT_EQ(result.tcm_v01.updated, control_main.tcm_v01.updated);
 }
 
-TEST(CppMessageTest, testEncodeControlMsgDetail1)
-{
-    rclcpp::NodeOptions options;
-    auto worker = std::make_shared<cpp_message::Node>(options);
-    // ControlMessage START
-    j2735_v2x_msgs::msg::TrafficControlMessage control_main;
-    control_main.choice = j2735_v2x_msgs::msg::TrafficControlMessage::TCMV01;
-    // ControlMessageV01 START
-    j2735_v2x_msgs::msg::TrafficControlMessageV01 control;
-    j2735_v2x_msgs::msg::Id64b id64b;
-    for(int i = 0; i < id64b.id.size(); i++){
-        id64b.id[i] = 0;
-    }
-    control.reqid = id64b;
-    control.reqseq = 111;
-    j2735_v2x_msgs::msg::Id128b id128b;
-    for(int i = 0; i < id128b.id.size(); i++){
-        id128b.id[i] = 0;
-    }
-    control.id = id128b;
-    control.msgnum = 5;
-    control.msgtot = 6;
-    control.updated = (unsigned)12345678;
+// TEST(CppMessageTest, testEncodeControlMsgDetail1)
+// {
+//     rclcpp::NodeOptions options;
+//     auto worker = std::make_shared<cpp_message::Node>(options);
+//     // ControlMessage START
+//     j2735_v2x_msgs::msg::TrafficControlMessage control_main;
+//     control_main.choice = j2735_v2x_msgs::msg::TrafficControlMessage::TCMV01;
+//     // ControlMessageV01 START
+//     j2735_v2x_msgs::msg::TrafficControlMessageV01 control;
+//     j2735_v2x_msgs::msg::Id64b id64b;
+//     for(int i = 0; i < id64b.id.size(); i++){
+//         id64b.id[i] = 0;
+//     }
+//     control.reqid = id64b;
+//     control.reqseq = 111;
+//     j2735_v2x_msgs::msg::Id128b id128b;
+//     for(int i = 0; i < id128b.id.size(); i++){
+//         id128b.id[i] = 0;
+//     }
+//     control.id = id128b;
+//     control.msgnum = 5;
+//     control.msgtot = 6;
+//     control.updated = (unsigned)12345678;
 
-    //==============================================
-    // ENABLES OPTIONAL FIELDS IN CONTROL MESSAGE
-    bool PACKAGE_BOOL = 1;
-    bool PARAM_BOOL = 1;
-    bool GEO_BOOL = 1;
+//     //==============================================
+//     // ENABLES OPTIONAL FIELDS IN CONTROL MESSAGE
+//     bool PACKAGE_BOOL = 1;
+//     bool PARAM_BOOL = 1;
+//     bool GEO_BOOL = 1;
 
-    //=======================================
-    // TrafficControlPackage START
-    j2735_v2x_msgs::msg::TrafficControlPackage package;
-    package.label = "avs";
-    package.label_exists = true;
-    for (auto i = 0; i < 2; i++) package.tcids.push_back(id128b);
-    control.package = package;
-    control.package_exists = PACKAGE_BOOL;
-    // TrafficControlPackage END
+//     //=======================================
+//     // TrafficControlPackage START
+//     j2735_v2x_msgs::msg::TrafficControlPackage package;
+//     package.label = "avs";
+//     package.label_exists = true;
+//     for (auto i = 0; i < 2; i++) package.tcids.push_back(id128b);
+//     control.package = package;
+//     control.package_exists = PACKAGE_BOOL;
+//     // TrafficControlPackage END
 
-    // TrafficControlParams START
-    j2735_v2x_msgs::msg::TrafficControlParams params;
-    params.regulatory = true;
-    j2735_v2x_msgs::msg::TrafficControlVehClass bycicle;
-    bycicle.vehicle_class = j2735_v2x_msgs::msg::TrafficControlVehClass::BICYCLE;
-    params.vclasses.push_back(bycicle);
-    j2735_v2x_msgs::msg::TrafficControlSchedule schedule;
-    schedule.between_exists = true;
-    schedule.dow_exists = true;
-    schedule.repeat_exists = true;
-    schedule.end_exists = true;
-    j2735_v2x_msgs::msg::DailySchedule daily_schedule;
-    daily_schedule.begin = 1;
-    daily_schedule.duration = 2;
-    schedule.between.push_back(daily_schedule);
-    schedule.start = (unsigned)123456;
-    schedule.end = (unsigned)123456;
-    j2735_v2x_msgs::msg::DayOfWeek dow;
-    dow.dow = {1,1,1,1,1,1,1};
-    schedule.dow = dow;
-    j2735_v2x_msgs::msg::RepeatParams repeat;
-    repeat.offset = (unsigned)1;
-    repeat.period = (unsigned)2;
-    repeat.span = (unsigned)3;
-    schedule.repeat = repeat;
-    params.schedule = schedule;
-    // TrafficControlDetails START
-    j2735_v2x_msgs::msg::TrafficControlDetail detail;
-    detail.choice = j2735_v2x_msgs::msg::TrafficControlDetail::MINPLATOONHDWY_CHOICE;
-    detail.minplatoonhdwy = 10;
+//     // TrafficControlParams START
+//     j2735_v2x_msgs::msg::TrafficControlParams params;
+//     params.regulatory = true;
+//     j2735_v2x_msgs::msg::TrafficControlVehClass bycicle;
+//     bycicle.vehicle_class = j2735_v2x_msgs::msg::TrafficControlVehClass::BICYCLE;
+//     params.vclasses.push_back(bycicle);
+//     j2735_v2x_msgs::msg::TrafficControlSchedule schedule;
+//     schedule.between_exists = true;
+//     schedule.dow_exists = true;
+//     schedule.repeat_exists = true;
+//     schedule.end_exists = true;
+//     j2735_v2x_msgs::msg::DailySchedule daily_schedule;
+//     daily_schedule.begin = 1;
+//     daily_schedule.duration = 2;
+//     schedule.between.push_back(daily_schedule);
+//     schedule.start = (unsigned)123456;
+//     schedule.end = (unsigned)123456;
+//     j2735_v2x_msgs::msg::DayOfWeek dow;
+//     dow.dow = {1,1,1,1,1,1,1};
+//     schedule.dow = dow;
+//     j2735_v2x_msgs::msg::RepeatParams repeat;
+//     repeat.offset = (unsigned)1;
+//     repeat.period = (unsigned)2;
+//     repeat.span = (unsigned)3;
+//     schedule.repeat = repeat;
+//     params.schedule = schedule;
+//     // TrafficControlDetails START
+//     j2735_v2x_msgs::msg::TrafficControlDetail detail;
+//     detail.choice = j2735_v2x_msgs::msg::TrafficControlDetail::MINPLATOONHDWY_CHOICE;
+//     detail.minplatoonhdwy = 10;
 
-    //boost::array<uint8_t, 2UL> stuff {{0 ,1}}; //
-    //detail.latperm = stuff;
+//     //boost::array<uint8_t, 2UL> stuff {{0 ,1}}; //
+//     //detail.latperm = stuff;
 
-    //ROS_WARN_STREAM("latperm og " << (int)detail.latperm.elems[0] << " | " << (int)detail.latperm.elems[1]);
-    // TrafficControlDetails END
-    params.detail = detail;
-    control.params = params;
-    control.params_exists = PARAM_BOOL;
-    // TrafficControlParams END
+//     //ROS_WARN_STREAM("latperm og " << (int)detail.latperm.elems[0] << " | " << (int)detail.latperm.elems[1]);
+//     // TrafficControlDetails END
+//     params.detail = detail;
+//     control.params = params;
+//     control.params_exists = PARAM_BOOL;
+//     // TrafficControlParams END
 
-    // TrafficControlGeometry START
-    j2735_v2x_msgs::msg::TrafficControlGeometry geometry;
-    geometry.proj = "this is a sample proj string";
-    geometry.datum = "this is a sample datum string";
-    geometry.reftime = (unsigned)1213;
-    geometry.reflon = 1;
-    geometry.reflat = 1;
-    geometry.refelv = 1;
-    geometry.heading = (unsigned)1;
-    j2735_v2x_msgs::msg::PathNode node;
-    node.x = 1;
-    node.y = 1;
-    node.z_exists = true;
-    node.z = 1;
-    node.width_exists = true;
-    node.width = 1;
-    geometry.nodes.push_back(node);
-    geometry.nodes.push_back(node);
-    control.geometry = geometry;
-    control.geometry_exists = GEO_BOOL;    
-    // TrafficControlGeometry END
-    // TrafficControlMessageV01 END
-    control_main.tcm_v01 = control;
-    // TrafficControlMessage END
-    auto res = worker->encode_geofence_control(control_main);
-    if(res) EXPECT_TRUE(true);
-    else
-    {
-        std::cout << "encoding failed!\n";
-        EXPECT_TRUE(false);
-    }
-    auto res_decoded = worker->decode_geofence_control(res.get());
+//     // TrafficControlGeometry START
+//     j2735_v2x_msgs::msg::TrafficControlGeometry geometry;
+//     geometry.proj = "this is a sample proj string";
+//     geometry.datum = "this is a sample datum string";
+//     geometry.reftime = (unsigned)1213;
+//     geometry.reflon = 1;
+//     geometry.reflat = 1;
+//     geometry.refelv = 1;
+//     geometry.heading = (unsigned)1;
+//     j2735_v2x_msgs::msg::PathNode node;
+//     node.x = 1;
+//     node.y = 1;
+//     node.z_exists = true;
+//     node.z = 1;
+//     node.width_exists = true;
+//     node.width = 1;
+//     geometry.nodes.push_back(node);
+//     geometry.nodes.push_back(node);
+//     control.geometry = geometry;
+//     control.geometry_exists = GEO_BOOL;    
+//     // TrafficControlGeometry END
+//     // TrafficControlMessageV01 END
+//     control_main.tcm_v01 = control;
+//     // TrafficControlMessage END
+//     auto res = worker->encode_geofence_control(control_main);
+//     if(res) EXPECT_TRUE(true);
+//     else
+//     {
+//         std::cout << "encoding failed!\n";
+//         EXPECT_TRUE(false);
+//     }
+//     auto res_decoded = worker->decode_geofence_control(res.get());
 
-    if(res_decoded) EXPECT_TRUE(true);
-    else
-    {
-        std::cout << "decoding of encoded file failed! \n";
-        EXPECT_TRUE(false);
-    }
-    j2735_v2x_msgs::msg::TrafficControlMessage result = res_decoded.get();
-    ASSERT_EQ(result.tcm_v01.params.detail.choice, j2735_v2x_msgs::msg::TrafficControlDetail::MINPLATOONHDWY_CHOICE);
-    ASSERT_EQ(result.tcm_v01.params.detail.minplatoonhdwy, 10);
-}
+//     if(res_decoded) EXPECT_TRUE(true);
+//     else
+//     {
+//         std::cout << "decoding of encoded file failed! \n";
+//         EXPECT_TRUE(false);
+//     }
+//     j2735_v2x_msgs::msg::TrafficControlMessage result = res_decoded.get();
+//     ASSERT_EQ(result.tcm_v01.params.detail.choice, j2735_v2x_msgs::msg::TrafficControlDetail::MINPLATOONHDWY_CHOICE);
+//     ASSERT_EQ(result.tcm_v01.params.detail.minplatoonhdwy, 10);
+// }
 
 TEST(CppMessageTest, testEncodeControlMsgDetail2)
 {

--- a/carma-messenger-core/cpp_message/test/test_encode_decode.cpp
+++ b/carma-messenger-core/cpp_message/test/test_encode_decode.cpp
@@ -81,9 +81,7 @@ TEST(CppMessageTest, testDecodeControlMsgParams)
     ASSERT_EQ(msg.params.detail.choice, j2735_v2x_msgs::msg::TrafficControlDetail::CLOSED_CHOICE);
     ASSERT_EQ(msg.params.schedule.between[0].begin, 1);
 
-    j2735_v2x_msgs::msg::TrafficControlMessage tcm;
-    tcm.tcm_v01 = msg;
-    auto res_encoded = worker->encode_geofence_control(tcm);
+    auto res_encoded = worker->encode_geofence_control(res.get());
     if(res_encoded) EXPECT_TRUE(true);
     else EXPECT_TRUE(false);
 }
@@ -117,9 +115,7 @@ TEST(CppMessageTest, testDecodeControlMsgGeometry)
     ASSERT_EQ(msg.geometry.reftime, 1213);
     ASSERT_EQ(msg.geometry.refelv, 1);
 
-    j2735_v2x_msgs::msg::TrafficControlMessage tcm;
-    tcm.tcm_v01 = msg;
-    auto res_encoded = worker->encode_geofence_control(tcm);
+    auto res_encoded = worker->encode_geofence_control(res.get());
     if(res_encoded) EXPECT_TRUE(true);
     else EXPECT_TRUE(false);
 }
@@ -142,6 +138,165 @@ TEST(CppMessageTest, testEncodeControlMsg1)
 }
 
 TEST(CppMessageTest, testEncodeControlMsg2)
+{
+    rclcpp::NodeOptions options;
+    auto worker = std::make_shared<cpp_message::Node>(options);
+    // ControlMessage START
+    j2735_v2x_msgs::msg::TrafficControlMessage control_main;
+    control_main.choice = j2735_v2x_msgs::msg::TrafficControlMessage::TCMV01;
+    // ControlMessageV01 START
+    j2735_v2x_msgs::msg::TrafficControlMessageV01 control;
+    j2735_v2x_msgs::msg::Id64b id64b;
+    for(int i = 0; i < id64b.id.size(); i++){
+        id64b.id[i] = i;
+    }
+    control.reqid = id64b;
+    control.reqseq = 111;
+    j2735_v2x_msgs::msg::Id128b id128b_0;
+    for(int i = 0; i < id128b_0.id.size(); i++){
+        id128b_0.id[i] = i + 20;
+    }
+    control.id = id128b_0;
+    control.msgnum = 5;
+    control.msgtot = 6;
+    control.updated = (unsigned)12345678;
+
+    //==============================================
+    // ENABLES OPTIONAL FIELDS IN CONTROL MESSAGE
+    bool PACKAGE_BOOL = 1;
+    bool PARAM_BOOL = 1;
+    bool GEO_BOOL = 1;
+
+    //=======================================
+    // TrafficControlPackage START
+    j2735_v2x_msgs::msg::TrafficControlPackage package;
+    package.label = "avs";
+    package.label_exists = true;
+    j2735_v2x_msgs::msg::Id128b id128b_1;
+    for(int i = 0; i < id128b_1.id.size(); i++){
+        id128b_1.id[i] = i + 40;
+    }
+    j2735_v2x_msgs::msg::Id128b id128b_2;
+    for(int i = 0; i < id128b_2.id.size(); i++){
+        id128b_2.id[i] = i + 60;
+    }
+    package.tcids.push_back(id128b_1);
+    package.tcids.push_back(id128b_2);
+    control.package = package;
+    control.package_exists = PACKAGE_BOOL;
+    // TrafficControlPackage END
+
+    // TrafficControlParams START
+    j2735_v2x_msgs::msg::TrafficControlParams params;
+    params.regulatory = true;
+    j2735_v2x_msgs::msg::TrafficControlVehClass bycicle;
+    bycicle.vehicle_class = j2735_v2x_msgs::msg::TrafficControlVehClass::BICYCLE;
+    params.vclasses.push_back(bycicle);
+    j2735_v2x_msgs::msg::TrafficControlSchedule schedule;
+    schedule.between_exists = true;
+    schedule.dow_exists = true;
+    schedule.repeat_exists = true;
+    schedule.end_exists = true;
+    j2735_v2x_msgs::msg::DailySchedule daily_schedule;
+    daily_schedule.begin = 1;
+    daily_schedule.duration = 2;
+    schedule.between.push_back(daily_schedule);
+    schedule.start = (unsigned)987123;
+    schedule.end = (unsigned)654321;
+    j2735_v2x_msgs::msg::DayOfWeek dow;
+    dow.dow = {1,0,1,1,1,1,1};
+    schedule.dow = dow;
+    j2735_v2x_msgs::msg::RepeatParams repeat;
+    repeat.offset = (unsigned)1;
+    repeat.period = (unsigned)9;
+    repeat.span = (unsigned)3;
+    schedule.repeat = repeat;
+    params.schedule = schedule;
+    // TrafficControlDetails START
+    j2735_v2x_msgs::msg::TrafficControlDetail detail;
+    detail.choice = j2735_v2x_msgs::msg::TrafficControlDetail::CLOSED_CHOICE;
+    detail.closed = j2735_v2x_msgs::msg::TrafficControlDetail::OPENLEFT;
+
+    //boost::array<uint8_t, 2UL> stuff {{0 ,1}}; //
+    //detail.latperm = stuff;
+
+    //ROS_WARN_STREAM("latperm og " << (int)detail.latperm.elems[0] << " | " << (int)detail.latperm.elems[1]);
+    // TrafficControlDetails END
+    params.detail = detail;
+    control.params = params;
+    control.params_exists = PARAM_BOOL;
+    // TrafficControlParams END
+
+    // TrafficControlGeometry START
+    j2735_v2x_msgs::msg::TrafficControlGeometry geometry;
+    geometry.proj = "this is a sample proj string";
+    geometry.datum = "this is a sample datum string";
+    geometry.reftime = (unsigned)1713;
+    geometry.reflon = 1;
+    geometry.reflat = 10;
+    geometry.refelv = 250;
+    geometry.heading = (unsigned)1;
+    j2735_v2x_msgs::msg::PathNode node;
+    node.x = 1;
+    node.y = 1;
+    node.z_exists = true;
+    node.z = 1;
+    node.width_exists = true;
+    node.width = 1;
+    j2735_v2x_msgs::msg::PathNode node2;
+    node2.x = 0;
+    node2.y = 1;
+    node2.z_exists = true;
+    node2.z = 0;
+    node2.width_exists = false;
+    geometry.nodes.push_back(node);
+    geometry.nodes.push_back(node2);
+    control.geometry = geometry;
+    control.geometry_exists = GEO_BOOL;    
+    // TrafficControlGeometry END
+    // TrafficControlMessageV01 END
+    control_main.tcm_v01 = control;
+
+    // TrafficControlMessage END
+    auto res = worker->encode_geofence_control(control_main);
+    if(res) EXPECT_TRUE(true);
+    else
+    {
+        std::cout << "encoding failed!\n";
+        EXPECT_TRUE(false);
+    }
+    auto res_decoded = worker->decode_geofence_control(res.get());
+
+    if(res_decoded) EXPECT_TRUE(true);
+    else
+    {
+        std::cout << "decoding of encoded file failed! \n";
+        EXPECT_TRUE(false);
+    }
+    j2735_v2x_msgs::msg::TrafficControlMessage result = res_decoded.get();
+    EXPECT_EQ(result.tcm_v01.id.id, control_main.tcm_v01.id.id);
+    EXPECT_EQ(result.tcm_v01.updated, control_main.tcm_v01.updated);
+
+
+    // TrafficControlMessage END
+    auto res2 = worker->encode_geofence_control(res_decoded.get());
+    if(res2) EXPECT_TRUE(true);
+    else
+    {
+        std::cout << "encoding failed!\n";
+        EXPECT_TRUE(false);
+    }
+    auto res_decoded2 = worker->decode_geofence_control(res2.get());
+
+    if(res_decoded2) EXPECT_TRUE(true);
+    else
+    {
+        std::cout << "decoding of encoded file failed! \n";
+        EXPECT_TRUE(false);
+    }
+}
+
+TEST(CppMessageTest, testEncodeControlMsgDetail1)
 {
     rclcpp::NodeOptions options;
     auto worker = std::make_shared<cpp_message::Node>(options);
@@ -209,8 +364,8 @@ TEST(CppMessageTest, testEncodeControlMsg2)
     params.schedule = schedule;
     // TrafficControlDetails START
     j2735_v2x_msgs::msg::TrafficControlDetail detail;
-    detail.choice = j2735_v2x_msgs::msg::TrafficControlDetail::CLOSED_CHOICE;
-    detail.closed = j2735_v2x_msgs::msg::TrafficControlDetail::OPENLEFT;
+    detail.choice = j2735_v2x_msgs::msg::TrafficControlDetail::MINPLATOONHDWY_CHOICE;
+    detail.minplatoonhdwy = 10;
 
     //boost::array<uint8_t, 2UL> stuff {{0 ,1}}; //
     //detail.latperm = stuff;
@@ -245,14 +400,6 @@ TEST(CppMessageTest, testEncodeControlMsg2)
     // TrafficControlGeometry END
     // TrafficControlMessageV01 END
     control_main.tcm_v01 = control;
-
-
-    auto TCM_pub_ = worker->create_publisher<j2735_v2x_msgs::msg::TrafficControlMessage>("test/defined_TCM", 5);
-    TCM_pub_->on_activate();
-    sleep(5);
-    TCM_pub_->publish(control_main);
-    sleep(1);
-
     // TrafficControlMessage END
     auto res = worker->encode_geofence_control(control_main);
     if(res) EXPECT_TRUE(true);
@@ -270,137 +417,9 @@ TEST(CppMessageTest, testEncodeControlMsg2)
         EXPECT_TRUE(false);
     }
     j2735_v2x_msgs::msg::TrafficControlMessage result = res_decoded.get();
-    sleep(1);
-    TCM_pub_->publish(result);
-    sleep(1);
-    EXPECT_EQ(result.tcm_v01.id.id, control_main.tcm_v01.id.id);
-    EXPECT_EQ(result.tcm_v01.updated, control_main.tcm_v01.updated);
+    ASSERT_EQ(result.tcm_v01.params.detail.choice, j2735_v2x_msgs::msg::TrafficControlDetail::MINPLATOONHDWY_CHOICE);
+    ASSERT_EQ(result.tcm_v01.params.detail.minplatoonhdwy, 10);
 }
-
-// TEST(CppMessageTest, testEncodeControlMsgDetail1)
-// {
-//     rclcpp::NodeOptions options;
-//     auto worker = std::make_shared<cpp_message::Node>(options);
-//     // ControlMessage START
-//     j2735_v2x_msgs::msg::TrafficControlMessage control_main;
-//     control_main.choice = j2735_v2x_msgs::msg::TrafficControlMessage::TCMV01;
-//     // ControlMessageV01 START
-//     j2735_v2x_msgs::msg::TrafficControlMessageV01 control;
-//     j2735_v2x_msgs::msg::Id64b id64b;
-//     for(int i = 0; i < id64b.id.size(); i++){
-//         id64b.id[i] = 0;
-//     }
-//     control.reqid = id64b;
-//     control.reqseq = 111;
-//     j2735_v2x_msgs::msg::Id128b id128b;
-//     for(int i = 0; i < id128b.id.size(); i++){
-//         id128b.id[i] = 0;
-//     }
-//     control.id = id128b;
-//     control.msgnum = 5;
-//     control.msgtot = 6;
-//     control.updated = (unsigned)12345678;
-
-//     //==============================================
-//     // ENABLES OPTIONAL FIELDS IN CONTROL MESSAGE
-//     bool PACKAGE_BOOL = 1;
-//     bool PARAM_BOOL = 1;
-//     bool GEO_BOOL = 1;
-
-//     //=======================================
-//     // TrafficControlPackage START
-//     j2735_v2x_msgs::msg::TrafficControlPackage package;
-//     package.label = "avs";
-//     package.label_exists = true;
-//     for (auto i = 0; i < 2; i++) package.tcids.push_back(id128b);
-//     control.package = package;
-//     control.package_exists = PACKAGE_BOOL;
-//     // TrafficControlPackage END
-
-//     // TrafficControlParams START
-//     j2735_v2x_msgs::msg::TrafficControlParams params;
-//     params.regulatory = true;
-//     j2735_v2x_msgs::msg::TrafficControlVehClass bycicle;
-//     bycicle.vehicle_class = j2735_v2x_msgs::msg::TrafficControlVehClass::BICYCLE;
-//     params.vclasses.push_back(bycicle);
-//     j2735_v2x_msgs::msg::TrafficControlSchedule schedule;
-//     schedule.between_exists = true;
-//     schedule.dow_exists = true;
-//     schedule.repeat_exists = true;
-//     schedule.end_exists = true;
-//     j2735_v2x_msgs::msg::DailySchedule daily_schedule;
-//     daily_schedule.begin = 1;
-//     daily_schedule.duration = 2;
-//     schedule.between.push_back(daily_schedule);
-//     schedule.start = (unsigned)123456;
-//     schedule.end = (unsigned)123456;
-//     j2735_v2x_msgs::msg::DayOfWeek dow;
-//     dow.dow = {1,1,1,1,1,1,1};
-//     schedule.dow = dow;
-//     j2735_v2x_msgs::msg::RepeatParams repeat;
-//     repeat.offset = (unsigned)1;
-//     repeat.period = (unsigned)2;
-//     repeat.span = (unsigned)3;
-//     schedule.repeat = repeat;
-//     params.schedule = schedule;
-//     // TrafficControlDetails START
-//     j2735_v2x_msgs::msg::TrafficControlDetail detail;
-//     detail.choice = j2735_v2x_msgs::msg::TrafficControlDetail::MINPLATOONHDWY_CHOICE;
-//     detail.minplatoonhdwy = 10;
-
-//     //boost::array<uint8_t, 2UL> stuff {{0 ,1}}; //
-//     //detail.latperm = stuff;
-
-//     //ROS_WARN_STREAM("latperm og " << (int)detail.latperm.elems[0] << " | " << (int)detail.latperm.elems[1]);
-//     // TrafficControlDetails END
-//     params.detail = detail;
-//     control.params = params;
-//     control.params_exists = PARAM_BOOL;
-//     // TrafficControlParams END
-
-//     // TrafficControlGeometry START
-//     j2735_v2x_msgs::msg::TrafficControlGeometry geometry;
-//     geometry.proj = "this is a sample proj string";
-//     geometry.datum = "this is a sample datum string";
-//     geometry.reftime = (unsigned)1213;
-//     geometry.reflon = 1;
-//     geometry.reflat = 1;
-//     geometry.refelv = 1;
-//     geometry.heading = (unsigned)1;
-//     j2735_v2x_msgs::msg::PathNode node;
-//     node.x = 1;
-//     node.y = 1;
-//     node.z_exists = true;
-//     node.z = 1;
-//     node.width_exists = true;
-//     node.width = 1;
-//     geometry.nodes.push_back(node);
-//     geometry.nodes.push_back(node);
-//     control.geometry = geometry;
-//     control.geometry_exists = GEO_BOOL;    
-//     // TrafficControlGeometry END
-//     // TrafficControlMessageV01 END
-//     control_main.tcm_v01 = control;
-//     // TrafficControlMessage END
-//     auto res = worker->encode_geofence_control(control_main);
-//     if(res) EXPECT_TRUE(true);
-//     else
-//     {
-//         std::cout << "encoding failed!\n";
-//         EXPECT_TRUE(false);
-//     }
-//     auto res_decoded = worker->decode_geofence_control(res.get());
-
-//     if(res_decoded) EXPECT_TRUE(true);
-//     else
-//     {
-//         std::cout << "decoding of encoded file failed! \n";
-//         EXPECT_TRUE(false);
-//     }
-//     j2735_v2x_msgs::msg::TrafficControlMessage result = res_decoded.get();
-//     ASSERT_EQ(result.tcm_v01.params.detail.choice, j2735_v2x_msgs::msg::TrafficControlDetail::MINPLATOONHDWY_CHOICE);
-//     ASSERT_EQ(result.tcm_v01.params.detail.minplatoonhdwy, 10);
-// }
 
 TEST(CppMessageTest, testEncodeControlMsgDetail2)
 {
@@ -500,8 +519,6 @@ TEST(CppMessageTest, testEncodeControlMsgDetail2)
     ASSERT_EQ(result.tcm_v01.params.detail.choice, j2735_v2x_msgs::msg::TrafficControlDetail::MAXPLATOONSIZE_CHOICE);
     ASSERT_EQ(result.tcm_v01.params.detail.maxplatoonsize, 10);
 }
-
-
 
 TEST(CppMessageTest, testDecodeRequestMsg1)
 {


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
The TCM encoder/decoder had some memory corruption issues. Primarily in sections of the message conversion, most obviously where there can be multiple loops through the same encoder. Some values were set in variables with a scope too small (only a for loop or function), which would get destroyed after that block executes, leaving another part of the code free to overwrite it. The solution was to give these variables a permanent memory allocation, which solved the issues. 

I used valgrind (install it in the dev container in vs code, then go to the built unit test (build/$package_name$), then run valgrind ./test_$package_name$) to find a few of the issues, but most eluded it, because they were the fault of freeing memory too early rather than going out of bounds, and valgrind didn't complain when the program use a pointer aimed at recently reallocated memory. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://usdot-carma.atlassian.net/browse/CAR-5400 and resolves https://github.com/usdot-fhwa-stol/carma-platform/issues/1763

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The carma-messenger TCM encoder has some issues with memory allocation, where some fields get overwritten by others. Testing was done in the develop branch on 5/10/2022, specifically the [testEncodeControlMsg2](https://github.com/usdot-fhwa-stol/carma-messenger/blob/develop/carma-messenger-core/cpp_message/test/test_encode_decode.cpp#L138) test in test_encode_decode of cpp_message.

Here is a summary of the symptoms:

- The first 8 elements of the tcid lists get written as the 8-byte representation of the geometry reftime (1213 turns into [0, 0, 0, 0, 0, 0, 4, 189])
- Both 16-element tcid lists are written as the second list
  - In the [code where these are stored](https://github.com/usdot-fhwa-stol/carma-messenger/blob/develop/carma-messenger-core/cpp_message/src/cpp_message.cpp#L1031), the data appears to be stored correctly, but when the second list of tcids is written, they overwrite the first list.
- The dow field under params/schedule/dow gets written as all 0s
- The nodes under geometry get their z and width fields set to 0

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I published TCM messages to a topic and echoed it to easily view the contents of individual messages, then compared a user-defined message to that same message after encoding/decoding. All of the original differences are listed above, and after the fixes are all resolved. I also added loops of encoding/decoding to unit tests; before the fixes, a message could not be decoded without throwing an exception. Now, messages can be encoded/decoded any number of times and remain untouched. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.