### PR TITLE
Fixed potential memory corruption issues

### DIFF
--- a/carma-messenger-core/cpp_message/src/BSM_Message.cpp
+++ b/carma-messenger-core/cpp_message/src/BSM_Message.cpp
@@ -141,7 +141,6 @@ namespace cpp_message
         temp_id->buf = id_content; 
         temp_id->size = 4;
         core_data->id = *temp_id;
-        free(temp_id);
         core_data->secMark = plain_msg.core_data.sec_mark;
 
         core_data->lat = plain_msg.core_data.latitude;
@@ -153,7 +152,6 @@ namespace cpp_message
         pos_acc->semiMajor = plain_msg.core_data.accuracy.semi_major;
         pos_acc->semiMinor = plain_msg.core_data.accuracy.semi_minor;
         core_data->accuracy = *pos_acc;
-        free(pos_acc);
         core_data->transmission = plain_msg.core_data.transmission.transmission_state;
         core_data->speed = plain_msg.core_data.speed;
         core_data->heading = plain_msg.core_data.heading;
@@ -165,13 +163,11 @@ namespace cpp_message
         accel->vert= plain_msg.core_data.accel_set.vert;
         accel->yaw = plain_msg.core_data.accel_set.yaw_rate;
         core_data->accelSet = *accel;
-        free(accel);
         VehicleSize_t* vehicle_size;
         vehicle_size = (VehicleSize_t*) calloc(1, sizeof(VehicleSize_t));
         vehicle_size->length = plain_msg.core_data.size.vehicle_length;
         vehicle_size->width = plain_msg.core_data.size.vehicle_width;
         core_data->size = *vehicle_size;
-        free(vehicle_size);
         BrakeSystemStatus_t* brakes;
         brakes = (BrakeSystemStatus_t*) calloc(1, sizeof(BrakeSystemStatus_t));
     
@@ -197,16 +193,12 @@ namespace cpp_message
         brakes->wheelBrakes = *brake_applied_status;
         
         core_data->brakes = *brakes;
-        free(brakes);
         bsm_msg->coreData = *core_data;
-        free(core_data);
         message->value.choice.BasicSafetyMessage = *bsm_msg;
-        free(bsm_msg);
         //encode message
         ec=uper_encode_to_buffer(&asn_DEF_MessageFrame, 0 , message , buffer , buffer_size);
         // Uncomment below to enable logging in human readable form
         //asn_fprint(fp, &asn_DEF_MessageFrame, message);
-        free(message);
         
         //log a warning if that fails
         if(ec.encoded == -1) {
@@ -219,6 +211,16 @@ namespace cpp_message
         size_t array_length=(ec.encoded + 7) / 8;
         std::vector<uint8_t> b_array(array_length);
         for(size_t i=0;i<array_length;i++)b_array[i]=buffer[i];
+
+        free(message);
+        free(bsm_msg);
+        free(core_data);
+        free(temp_id);
+        free(pos_acc);
+        free(accel);
+        free(vehicle_size);
+        free(brakes);
+        free(brake_applied_status);
                 
         //Debugging/Unit Testing
         //for(size_t i = 0; i < array_length; i++) std::cout<< int(b_array[i])<< ", ";

--- a/carma-messenger-core/cpp_message/src/BSM_Message.cpp
+++ b/carma-messenger-core/cpp_message/src/BSM_Message.cpp
@@ -108,77 +108,62 @@ namespace cpp_message
         uint8_t buffer[544];
         size_t buffer_size=sizeof(buffer);
         asn_enc_rval_t ec;
-        MessageFrame_t* message;
-        message = (MessageFrame_t*) calloc(1, sizeof(MessageFrame_t));
-        
-
-        //if mem allocation fails
-        if(!message)
-        {
-            RCLCPP_WARN_STREAM( node_logging_->get_logger(), "Cannot allocate mem for BasicSafetyMessage encoding");
-            return boost::optional<std::vector<uint8_t>>{};
-        }
+        MessageFrame_t message;
 
         //set message type to BasicSafetyMessage
-        message->messageId = 20;  
-        message->value.present = MessageFrame__value_PR_BasicSafetyMessage;
+        message.messageId = 20;  
+        message.value.present = MessageFrame__value_PR_BasicSafetyMessage;
 
-        BasicSafetyMessage* bsm_msg;
-        bsm_msg = (BasicSafetyMessage*) calloc(1, sizeof(BasicSafetyMessage));
+        BasicSafetyMessage bsm_msg;
+        bsm_msg.partII = nullptr;
+        bsm_msg.regional = nullptr;
 
         // Encode coreData
-        BSMcoreData_t* core_data;
-        core_data = (BSMcoreData_t*) calloc(1, sizeof(BSMcoreData_t));
-        core_data->msgCnt = plain_msg.core_data.msg_count;
+        BSMcoreData_t core_data;
+        core_data.msgCnt = plain_msg.core_data.msg_count;
         //Set the fields
         uint8_t id_content[4] = {0};
         for(auto i = 0; i < 4; i++)
         {
             id_content[i] = (char) plain_msg.core_data.id[i];
         }
-        TemporaryID_t* temp_id;
-        temp_id = (TemporaryID_t*) calloc(1, sizeof(TemporaryID_t));
-        temp_id->buf = id_content; 
-        temp_id->size = 4;
-        core_data->id = *temp_id;
-        core_data->secMark = plain_msg.core_data.sec_mark;
+        TemporaryID_t temp_id;
+        temp_id.buf = id_content; 
+        temp_id.size = 4;
+        core_data.id = temp_id;
+        core_data.secMark = plain_msg.core_data.sec_mark;
 
-        core_data->lat = plain_msg.core_data.latitude;
-        core_data->Long = plain_msg.core_data.longitude;
-        core_data->elev = plain_msg.core_data.elev;
-        PositionalAccuracy_t* pos_acc;
-        pos_acc = (PositionalAccuracy_t*) calloc(1, sizeof(PositionalAccuracy_t));
-        pos_acc->orientation = plain_msg.core_data.accuracy.orientation;
-        pos_acc->semiMajor = plain_msg.core_data.accuracy.semi_major;
-        pos_acc->semiMinor = plain_msg.core_data.accuracy.semi_minor;
-        core_data->accuracy = *pos_acc;
-        core_data->transmission = plain_msg.core_data.transmission.transmission_state;
-        core_data->speed = plain_msg.core_data.speed;
-        core_data->heading = plain_msg.core_data.heading;
-        core_data->angle = plain_msg.core_data.angle;
-        AccelerationSet4Way_t* accel;
-        accel = (AccelerationSet4Way_t*) calloc(1, sizeof(AccelerationSet4Way_t));
-        accel->lat = plain_msg.core_data.accel_set.lateral;
-        accel->Long = plain_msg.core_data.accel_set.longitudinal;
-        accel->vert= plain_msg.core_data.accel_set.vert;
-        accel->yaw = plain_msg.core_data.accel_set.yaw_rate;
-        core_data->accelSet = *accel;
-        VehicleSize_t* vehicle_size;
-        vehicle_size = (VehicleSize_t*) calloc(1, sizeof(VehicleSize_t));
-        vehicle_size->length = plain_msg.core_data.size.vehicle_length;
-        vehicle_size->width = plain_msg.core_data.size.vehicle_width;
-        core_data->size = *vehicle_size;
-        BrakeSystemStatus_t* brakes;
-        brakes = (BrakeSystemStatus_t*) calloc(1, sizeof(BrakeSystemStatus_t));
+        core_data.lat = plain_msg.core_data.latitude;
+        core_data.Long = plain_msg.core_data.longitude;
+        core_data.elev = plain_msg.core_data.elev;
+        PositionalAccuracy_t pos_acc;
+        pos_acc.orientation = plain_msg.core_data.accuracy.orientation;
+        pos_acc.semiMajor = plain_msg.core_data.accuracy.semi_major;
+        pos_acc.semiMinor = plain_msg.core_data.accuracy.semi_minor;
+        core_data.accuracy = pos_acc;
+        core_data.transmission = plain_msg.core_data.transmission.transmission_state;
+        core_data.speed = plain_msg.core_data.speed;
+        core_data.heading = plain_msg.core_data.heading;
+        core_data.angle = plain_msg.core_data.angle;
+        AccelerationSet4Way_t accel;
+        accel.lat = plain_msg.core_data.accel_set.lateral;
+        accel.Long = plain_msg.core_data.accel_set.longitudinal;
+        accel.vert= plain_msg.core_data.accel_set.vert;
+        accel.yaw = plain_msg.core_data.accel_set.yaw_rate;
+        core_data.accelSet = accel;
+        VehicleSize_t vehicle_size;
+        vehicle_size.length = plain_msg.core_data.size.vehicle_length;
+        vehicle_size.width = plain_msg.core_data.size.vehicle_width;
+        core_data.size = vehicle_size;
+        BrakeSystemStatus_t brakes;
     
-        brakes->traction = plain_msg.core_data.brakes.traction.traction_control_status;
-        brakes->abs = plain_msg.core_data.brakes.abs.anti_lock_brake_status;
-        brakes->scs = plain_msg.core_data.brakes.scs.stability_control_status;
-        brakes->brakeBoost = plain_msg.core_data.brakes.brake_boost.brake_boost_applied;
-        brakes->auxBrakes = plain_msg.core_data.brakes.aux_brakes.auxiliary_brake_status;
+        brakes.traction = plain_msg.core_data.brakes.traction.traction_control_status;
+        brakes.abs = plain_msg.core_data.brakes.abs.anti_lock_brake_status;
+        brakes.scs = plain_msg.core_data.brakes.scs.stability_control_status;
+        brakes.brakeBoost = plain_msg.core_data.brakes.brake_boost.brake_boost_applied;
+        brakes.auxBrakes = plain_msg.core_data.brakes.aux_brakes.auxiliary_brake_status;
         
-        BrakeAppliedStatus_t* brake_applied_status;
-        brake_applied_status = (BrakeAppliedStatus_t*) calloc(1, sizeof(BrakeAppliedStatus_t));
+        BrakeAppliedStatus_t brake_applied_status;
         
         uint8_t wheel_brake[1] = {8}; // dummy 8 value
 
@@ -187,16 +172,16 @@ namespace cpp_message
         // so num in brackets indicate the position in the bit string:
         // unavailable: 0b10000000, leftFront: 0b01000000 etc
         wheel_brake[0] = (char) (8 << (4 - plain_msg.core_data.brakes.wheel_brakes.brake_applied_status)); 
-        brake_applied_status->buf = wheel_brake;
-        brake_applied_status->size = 1;
-        brake_applied_status->bits_unused = 3;
-        brakes->wheelBrakes = *brake_applied_status;
+        brake_applied_status.buf = wheel_brake;
+        brake_applied_status.size = 1;
+        brake_applied_status.bits_unused = 3;
+        brakes.wheelBrakes = brake_applied_status;
         
-        core_data->brakes = *brakes;
-        bsm_msg->coreData = *core_data;
-        message->value.choice.BasicSafetyMessage = *bsm_msg;
+        core_data.brakes = brakes;
+        bsm_msg.coreData = core_data;
+        message.value.choice.BasicSafetyMessage = bsm_msg;
         //encode message
-        ec=uper_encode_to_buffer(&asn_DEF_MessageFrame, 0 , message , buffer , buffer_size);
+        ec=uper_encode_to_buffer(&asn_DEF_MessageFrame, 0 , &message , buffer , buffer_size);
         // Uncomment below to enable logging in human readable form
         //asn_fprint(fp, &asn_DEF_MessageFrame, message);
         
@@ -211,17 +196,7 @@ namespace cpp_message
         size_t array_length=(ec.encoded + 7) / 8;
         std::vector<uint8_t> b_array(array_length);
         for(size_t i=0;i<array_length;i++)b_array[i]=buffer[i];
-
-        free(message);
-        free(bsm_msg);
-        free(core_data);
-        free(temp_id);
-        free(pos_acc);
-        free(accel);
-        free(vehicle_size);
-        free(brakes);
-        free(brake_applied_status);
-                
+        
         //Debugging/Unit Testing
         //for(size_t i = 0; i < array_length; i++) std::cout<< int(b_array[i])<< ", ";
         return boost::optional<std::vector<uint8_t>>(b_array);

--- a/carma-messenger-core/cpp_message/test/node_test.cpp
+++ b/carma-messenger-core/cpp_message/test/node_test.cpp
@@ -29,6 +29,8 @@ int main(int argc, char ** argv)
     //Initialize ROS
     rclcpp::init(argc, argv);
     
+    // Running specific unit tests
+    //::testing::GTEST_FLAG(filter) = "BSM*";
     bool success = RUN_ALL_TESTS();
 
     //shutdown ROS

--- a/carma-messenger-core/cpp_message/test/node_test.cpp
+++ b/carma-messenger-core/cpp_message/test/node_test.cpp
@@ -30,7 +30,7 @@ int main(int argc, char ** argv)
     rclcpp::init(argc, argv);
     
     // Running specific unit tests
-    //::testing::GTEST_FLAG(filter) = "BSM*";
+    // ::testing::GTEST_FLAG(filter) = "BSM*";
     bool success = RUN_ALL_TESTS();
 
     //shutdown ROS

--- a/carma-messenger-core/cpp_message/test/test_BSM.cpp
+++ b/carma-messenger-core/cpp_message/test/test_BSM.cpp
@@ -89,12 +89,64 @@ TEST(BSMTest, testEncodeBSM)
         size_t len=to_read.size();
         for(size_t i=0;i<len;i++)std::cout<<int(to_read[i])<<",";
         std::cout<<"\n";
-        
         EXPECT_TRUE(true);
     }
     else
     {
         std::cout << "Encoding failed while unit testing BSM encoder!\n";
+        EXPECT_TRUE(false);
+    }
+}
+
+TEST(BSMTest, testEncodeDecodeBSM)
+{
+    auto node = std::make_shared<rclcpp::Node>("test_node");
+    cpp_message::BSM_Message worker(node->get_node_logging_interface());    
+    j2735_v2x_msgs::msg::BSM message;
+    message.core_data.msg_count = 1;
+    message.core_data.id = {1,2,3,4};
+    message.core_data.sec_mark = 2;
+    message.core_data.longitude = 3;
+    message.core_data.accuracy.orientation = 4;
+    message.core_data.brakes.wheel_brakes.brake_applied_status = j2735_v2x_msgs::msg::BrakeAppliedStatus::RIGHT_REAR;
+    message.core_data.brakes.traction.traction_control_status = 1;
+    message.core_data.brakes.abs.anti_lock_brake_status = 1;
+    message.core_data.brakes.scs.stability_control_status = 1;
+    message.core_data.brakes.brake_boost.brake_boost_applied = 1;
+    message.core_data.brakes.aux_brakes.auxiliary_brake_status = 1;
+    message.core_data.accel_set.yaw_rate = 18;
+    message.core_data.size.vehicle_width = 19;
+    message.core_data.size.vehicle_length = 20;
+
+    auto res = worker.encode_bsm_message(message);
+    if(res) EXPECT_TRUE(true);
+    else 
+    {
+        std::cout << "Encoding failed while unit testing BSM encoder!\n";
+        EXPECT_TRUE(false);
+    }
+    auto res_decoded = worker.decode_bsm_message(res.get());
+    if(res_decoded) EXPECT_TRUE(true);
+    else
+    {
+        std::cout << "decoding of encoded file failed! \n";
+        EXPECT_TRUE(false);
+    }
+    j2735_v2x_msgs::msg::BSM result = res_decoded.get();
+    EXPECT_EQ(message, result);
+
+    auto res2 = worker.encode_bsm_message(result);
+    if(res2) EXPECT_TRUE(true);
+    else 
+    {
+        std::cout << "Encoding failed while unit testing BSM encoder!\n";
+        EXPECT_TRUE(false);
+    }
+    auto res2_decoded = worker.decode_bsm_message(res2.get());
+    if(res2_decoded) EXPECT_TRUE(true);
+    else
+    {
+        std::cout << "decoding of encoded file failed! \n";
         EXPECT_TRUE(false);
     }
 }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://usdot-carma.atlassian.net/browse/CAR-5642 and resolves https://github.com/usdot-fhwa-stol/carma-platform/issues/1917

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
There was one for-sure memory leak in the code, brake_applied_status which was allocated with calloc but never freed. There were also 8 instances of potential memory corruption, where a variable was allocated with calloc, a pointer to its data stored into a field of the message, but was freed immediately. ex: the below image. Valgrind didn't detect this as an error, maybe because this specific encoder is so small that there is only a small chance that any individual block of memory is tampered with before the message is encoded and it is no longer needed. I searched around for a way to pull these kinds of errors out of the woodwork, but it may just have to be a manual thing. 

![potential memory corruption issue not caught by valgrind](https://user-images.githubusercontent.com/65964406/187542224-d2567a1f-7b08-4ca6-afd8-38d11e4bbf33.png)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added a new unit test, testEncodeDecodeBSM, in test_BSM.cpp. If any field of the message is different after encoding/decoding, the test fails. I also ran valgrind to identify memory leaks while running the unit test. I wasn't able to fix all of the memory leaks, because some appear to be built into the asn1c uper encoder/decoder, and there appears to be one in ros as well. More details on those here: https://usdot-carma.atlassian.net/wiki/spaces/CRMPLT/pages/2314469377/Checking+code+for+memory+corruption+and+memory+leak+issues

Before the fixes were implemented, there is one extra memory leak detected:
LEAK SUMMARY:
definitely lost: 2,128 bytes in 29 blocks
indirectly lost: 1,818 bytes in 40 blocks
possibly lost: 4,168 bytes in 1 blocks
ERROR SUMMARY: 30 errors from 30 contexts (suppressed: 0 from 0)

With the fixes implemented, the unit test passes, and there are fewer memory leaks:
LEAK SUMMARY:
definitely lost: 2,032 bytes in 27 blocks
indirectly lost: 1,818 bytes in 40 blocks
possibly lost: 4,168 bytes in 1 blocks
ERROR SUMMARY: 28 errors from 28 contexts (suppressed: 0 from 0)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.