### PR TITLE
fix mobility operations message encoder memory

### DIFF
--- a/carma-messenger-core/cpp_message/src/MobilityOperation_Message.cpp
+++ b/carma-messenger-core/cpp_message/src/MobilityOperation_Message.cpp
@@ -149,14 +149,8 @@ namespace cpp_message
         size_t buffer_size=sizeof(buffer);
         
         asn_enc_rval_t ec;
-        std::shared_ptr<MessageFrame_t>message_shared(new MessageFrame_t);
-        //if mem allocation fails
-        if(!message_shared)
-        {
-            RCLCPP_WARN_STREAM(node_logging_->get_logger(), "Cannot allocate mem for MobilityOperation message encoding");
-            return boost::optional<std::vector<uint8_t>>{};
-        }
-        MessageFrame_t* message=message_shared.get();
+        auto message_shared = std::make_shared<MessageFrame_t>();
+        MessageFrame_t* message = message_shared.get();
         //set message type to TestMessage03
         message->messageId=MOBILITY_OPERATION_TEST_ID;  
         message->value.present=MessageFrame__value_PR_TestMessage03;    
@@ -297,8 +291,4 @@ namespace cpp_message
         //for(size_t i = 0; i < array_length; i++) std::cout<< int(b_array[i])<< ", ";
         return boost::optional<std::vector<uint8_t>>(b_array);
     }
-    
-   
-
-
 }

--- a/carma-messenger-core/cpp_message/test/node_test.cpp
+++ b/carma-messenger-core/cpp_message/test/node_test.cpp
@@ -29,6 +29,8 @@ int main(int argc, char ** argv)
     //Initialize ROS
     rclcpp::init(argc, argv);
     
+    // Running specific unit tests
+    // ::testing::GTEST_FLAG(filter) = "BSM*";
     bool success = RUN_ALL_TESTS();
 
     //shutdown ROS

--- a/carma-messenger-core/cpp_message/test/test_MobilityOperations.cpp
+++ b/carma-messenger-core/cpp_message/test/test_MobilityOperations.cpp
@@ -66,6 +66,55 @@ TEST(MobilityOperationMessageTest, testEncodeMobilityOperationMsg)
     }
 }
 
+TEST(MobilityOperationMessageTest, testEncodeDecodeMobilityOperationMsg)
+{
+    auto node = std::make_shared<rclcpp::Node>("test_node");
+    cpp_message::Mobility_Operation worker(node->get_node_logging_interface());
+    carma_v2x_msgs::msg::MobilityHeader header;
+    carma_v2x_msgs::msg::MobilityOperation message;     
+    header.sender_id="USDOT-45100";
+    header.recipient_id="USDOT-45095";
+    header.sender_bsm_id="10ABCDEF";
+    header.plan_id="11111111-2222-3333-AAAA-111111111111";
+    header.timestamp = 9223372036854775807;
+    message.m_header=header;
+    message.strategy="Carma/Platooning";
+    message.strategy_params="vin_number:1FUJGHDV0CLBP8834,license_plate:DOT-10003,carrier_name:Silver Truck FHWA TFHRC,carrier_id:USDOT 0000001,weight:,ads_software_version:System Version Unknown,date_of_last_state_inspection:YYYY-MM-DD,date_of_last_ads_calibration:YYYY-MM-DD,pre_trip_ads_health_check:Green,ads_status:Red,iss_score:49,permit_required:0,timestamp:1585836731814";
+    auto res = worker.encode_mobility_operation_message(message);
+
+    if(res) EXPECT_TRUE(true);
+    else
+    {
+        std::cout << "encoding failed!\n";
+        EXPECT_TRUE(false);
+    }
+    auto res_decoded = worker.decode_mobility_operation_message(res.get());
+    if(res_decoded) EXPECT_TRUE(true);
+    else
+    {
+        std::cout << "decoding of encoded file failed! \n";
+        EXPECT_TRUE(false);
+    }
+    carma_v2x_msgs::msg::MobilityOperation result = res_decoded.get();
+    EXPECT_EQ(message, result);
+
+    auto res2 = worker.encode_mobility_operation_message(result);
+    if(res2) EXPECT_TRUE(true);
+    else 
+    {
+        std::cout << "Encoding failed while unit testing BSM encoder!\n";
+        EXPECT_TRUE(false);
+    }
+    auto res2_decoded = worker.decode_mobility_operation_message(res2.get());
+    if(res2_decoded) EXPECT_TRUE(true);
+    else
+    {
+        std::cout << "decoding of encoded file failed! \n";
+        EXPECT_TRUE(false);
+    }
+    EXPECT_EQ(message, res2_decoded.get());
+}
+
 TEST(MobilityOperationMessageTest, testEncodeMobilityOperationMsg_base_case)
 {
     auto node = std::make_shared<rclcpp::Node>("test_node");


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://usdot-carma.atlassian.net/browse/CAR-5644 and resolves https://github.com/usdot-fhwa-stol/carma-platform/issues/1920

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The code didn't have any memory leaks or memory corruption issues, but it was cleaned up a bit, and a unit test was added to detect memory corruption in the future. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added a new unit test, testEncodeDecodeMobilityOperationMsg, in test_MobilityOperations.cpp. If any field of the message is different after encoding/decoding, the test fails. I also ran valgrind to identify memory leaks while running the unit test. I wasn't able to fix all of the memory leaks, because some appear to be built into the asn1c uper encoder/decoder, ros, and the atoll function. More details on those here: https://usdot-carma.atlassian.net/wiki/spaces/CRMPLT/pages/2314469377/Checking+code+for+memory+corruption+and+memory+leak+issues

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.