### PR TITLE
Cleaned up code, no memory leaks to fix

### DIFF
--- a/carma-messenger-core/cpp_message/include/cpp_message/MobilityRequest_Message.h
+++ b/carma-messenger-core/cpp_message/include/cpp_message/MobilityRequest_Message.h
@@ -41,9 +41,6 @@ namespace cpp_message
         static const int OFFSET_MAX=500;
         static const int OFFSET_UNAVAILABLE=501;
 
-        //a vector of pointers to MobilityECEFOffset messages,for deleting unsafely allocated offset messages while encoding.
-        std::vector<MobilityECEFOffset_t*> Offset_ptrs;  
-
         public:
         /**
         * \brief constructor 
@@ -67,7 +64,5 @@ namespace cpp_message
          * @return encoded byte array returns an empty optional if encoding fails. 
          */
         boost::optional<std::vector<uint8_t>> encode_mobility_request_message(carma_v2x_msgs::msg::MobilityRequest plainMessage);
-
-        ~Mobility_Request();
     };
 }

--- a/carma-messenger-core/cpp_message/test/node_test.cpp
+++ b/carma-messenger-core/cpp_message/test/node_test.cpp
@@ -29,6 +29,8 @@ int main(int argc, char ** argv)
     //Initialize ROS
     rclcpp::init(argc, argv);
     
+    // Running specific unit tests
+    // ::testing::GTEST_FLAG(filter) = "BSM*";
     bool success = RUN_ALL_TESTS();
 
     //shutdown ROS

--- a/carma-messenger-core/cpp_message/test/test_MobilityRequest.cpp
+++ b/carma-messenger-core/cpp_message/test/test_MobilityRequest.cpp
@@ -145,6 +145,96 @@ TEST(MobilityRequestMessageTest, testEncodeMobilityRequestMsg)
     }
 }
 
+TEST(MobilityRequestMessageTest, testEncodeDecodeMobilityRequestMsg)
+{
+    auto node = std::make_shared<rclcpp::Node>("test_node");
+    cpp_message::Mobility_Request worker(node->get_node_logging_interface());
+    carma_v2x_msgs::msg::MobilityHeader header;
+    carma_v2x_msgs::msg::MobilityRequest message;
+    header.sender_id="USDOT-45100";
+    header.recipient_id="USDOT-45095";
+    header.sender_bsm_id="10ABCDEF";
+    header.plan_id="11111111-2222-3333-AAAA-111111111111";
+    header.timestamp = 9223372036854775807;
+    message.m_header=header;   
+
+    //body
+    message.strategy="Carma/Platooning";
+    message.plan_type.type=4;
+    message.urgency=50;
+    
+        //location
+    carma_v2x_msgs::msg::LocationECEF starting_location;
+    starting_location.ecef_x=0;
+    starting_location.ecef_y=1;
+    starting_location.ecef_z=2;
+    starting_location.timestamp=1223372036854775807;
+
+    message.location=starting_location;
+        //strategy_params
+    message.strategy_params="vin_number:1FUJGHDV0CLBP8834,license_plate:DOT-10003,carrier_name:Silver Truck FHWA TFHRC,carrier_id:USDOT 0000001,weight:,ads_software_version:System Version Unknown,date_of_last_state_inspection:YYYY-MM-DD,date_of_last_ads_calibration:YYYY-MM-DD,pre_trip_ads_health_check:Green,ads_status:Red,iss_score:49,permit_required:0,timestamp:1585836731814";
+        //trajectory
+    carma_v2x_msgs::msg::Trajectory trajectory;
+    carma_v2x_msgs::msg::LocationECEF trajectory_start;
+    trajectory_start.ecef_x=5;
+    trajectory_start.ecef_y=1;
+    trajectory_start.ecef_z=2;
+    trajectory_start.timestamp=9023372036854775807;
+    trajectory.location=trajectory_start;
+
+            //offsets
+    carma_v2x_msgs::msg::LocationOffsetECEF offset1;
+    offset1.offset_x=1;
+    offset1.offset_y=1;
+    offset1.offset_z=1;
+
+    trajectory.offsets.push_back(offset1);
+ 
+    carma_v2x_msgs::msg::LocationOffsetECEF offset2;
+    offset2.offset_x=2;
+    offset2.offset_y=2;
+    offset2.offset_z=2;
+
+    trajectory.offsets.push_back(offset2);
+
+    message.trajectory=trajectory;
+    //expiration
+    message.expiration=1523372036854775807;
+    boost::optional<std::vector<uint8_t>> res = worker.encode_mobility_request_message(message);
+    
+    if(res) EXPECT_TRUE(true);
+    else
+    {
+        std::cout << "encoding failed!\n";
+        EXPECT_TRUE(false);
+    }
+    auto res_decoded = worker.decode_mobility_request_message(res.get());
+    if(res_decoded) EXPECT_TRUE(true);
+    else
+    {
+        std::cout << "decoding of encoded file failed! \n";
+        EXPECT_TRUE(false);
+    }
+    carma_v2x_msgs::msg::MobilityRequest result = res_decoded.get();
+    EXPECT_EQ(message, result);
+
+    auto res2 = worker.encode_mobility_request_message(result);
+    if(res2) EXPECT_TRUE(true);
+    else 
+    {
+        std::cout << "Encoding failed while unit testing BSM encoder!\n";
+        EXPECT_TRUE(false);
+    }
+    auto res2_decoded = worker.decode_mobility_request_message(res2.get());
+    if(res2_decoded) EXPECT_TRUE(true);
+    else
+    {
+        std::cout << "decoding of encoded file failed! \n";
+        EXPECT_TRUE(false);
+    }
+    EXPECT_EQ(message, res2_decoded.get());
+}
+
 TEST(MobilityRequestMessageTest, testEncodeMobilityRequestMsg_base_case)
 {
     auto node = std::make_shared<rclcpp::Node>("test_node");
@@ -209,6 +299,3 @@ TEST(MobilityRequestMessageTest, testEncodeMobilityRequestMsg_base_case)
         EXPECT_TRUE(false);
     }
 }
-
-
-


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://usdot-carma.atlassian.net/browse/CAR-5646 and resolves https://github.com/usdot-fhwa-stol/carma-platform/issues/1922

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The code didn't have any memory leaks or memory corruption issues, but it was cleaned up a bit, and a unit test was added to detect memory corruption in the future. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added a new unit test, testEncodeDecodeMobilityRequestMsg, in test_MobilityRequest.cpp. If any field of the message is different after encoding/decoding, the test fails. I also ran valgrind to identify memory leaks while running the unit test. I wasn't able to fix all of the memory leaks, because some appear to be built into the asn1c uper encoder/decoder, ros, and the atoll function. More details on those here: https://usdot-carma.atlassian.net/wiki/spaces/CRMPLT/pages/2314469377/Checking+code+for+memory+corruption+and+memory+leak+issues

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.