### PR TITLE
fixed mobility path crash

### DIFF
--- a/carma-messenger-core/cpp_message/src/MobilityPath_Message.cpp
+++ b/carma-messenger-core/cpp_message/src/MobilityPath_Message.cpp
@@ -406,8 +406,6 @@ namespace cpp_message
         for (size_t i = 0; i < array_length; i++)
             b_array[i] = buffer[i];
 
-        ASN_STRUCT_FREE(asn_DEF_MessageFrame, message);
-        // ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_MobilityLocationOffsets, &offsets_list);
         return boost::optional<std::vector<uint8_t>>(b_array);
     }
 }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Fixing an issue where the mobility path generation would fail. 

Accidentally left in a line that causes a double free and hence a seg fault.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tan existing unit tests, all passed

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.