### PR TITLE
Remove support for /get_emergency_route service from emergency_response_vehicle_plugin

### DIFF
--- a/carma-messenger-core/emergency_response_vehicle_plugin/include/emergency_response_vehicle_plugin/emergency_response_vehicle_plugin_node.hpp
+++ b/carma-messenger-core/emergency_response_vehicle_plugin/include/emergency_response_vehicle_plugin/emergency_response_vehicle_plugin_node.hpp
@@ -32,11 +32,9 @@
 #include "carma_v2x_msgs/msg/emergency_vehicle_ack.hpp"
 #include "carma_v2x_msgs/msg/emergency_vehicle_response.hpp"
 #include "j2735_v2x_msgs/msg/special_vehicle_extensions.hpp"
-#include "carma_planning_msgs/srv/get_emergency_route.hpp"
 #include "carma_msgs/msg/ui_instructions.hpp"
 #include "gps_msgs/msg/gps_fix.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
-#include "carma_planning_msgs/srv/get_emergency_route.hpp"
 #include "std_srvs/srv/trigger.hpp"
 
 #include "emergency_response_vehicle_plugin/udp_listener.hpp"
@@ -62,7 +60,6 @@ namespace emergency_response_vehicle_plugin
     carma_ros2_utils::PubPtr<carma_msgs::msg::UIInstructions> emergency_vehicle_ui_warnings_pub_;
 
     // Service Servers
-    carma_ros2_utils::ServicePtr<carma_planning_msgs::srv::GetEmergencyRoute> get_emergency_route_server_;
     carma_ros2_utils::ServicePtr<std_srvs::srv::Trigger> arrived_at_emergency_destination_server_;
 
     // Node configuration

--- a/carma-messenger-core/emergency_response_vehicle_plugin/include/emergency_response_vehicle_plugin/emergency_response_vehicle_plugin_node.hpp
+++ b/carma-messenger-core/emergency_response_vehicle_plugin/include/emergency_response_vehicle_plugin/emergency_response_vehicle_plugin_node.hpp
@@ -74,9 +74,6 @@ namespace emergency_response_vehicle_plugin
     // Ordered future route destination points for the Emergency Response Vehicle; final point is the destination point
     std::vector<carma_v2x_msgs::msg::Position3D> route_destination_points_;
 
-    // Name of the final destination of the loaded route for this Emergency Response Vehicle. Name is communicated to the Emergency Response Web UI
-    std::string route_final_destination_name_;
-
     // The BSM ID of the Emergency Response Vehicle as a string
     std::string bsm_id_string_;
 
@@ -140,8 +137,7 @@ namespace emergency_response_vehicle_plugin
     /**
      * \brief Function to extract the route destination points from a .csv file stored on the Host PC at the file path
      * provided in the route_file_path argument. Route destination points are stored sequentially within the plugin's
-     * route_destination_points_ member object. Additionally, the name of the final destination is stored within the plugin's
-     * route_final_destination_name_ member object.
+     * route_destination_points_ member object.
      * \param route_file_path The file path on the Host PC that contains the .csv file for the Emergency Response Vehicle's route destination points.
      * \return A vector containing the sequential route destination points that describe the Emergency Response Vehicle's route at startup.
      */
@@ -169,23 +165,9 @@ namespace emergency_response_vehicle_plugin
     void publishBSM();
 
     /**
-     * \brief Service callback for a request of the name of the final destination of an Emergency Response Vehicle's 
-     * planned route. This service is called by the Emergency Response Web UI Widget at initial startup of the UI.
-     * \param req An empty carma_planning_msgs::srv::GetEmergencyRoute::Request.
-     * \param resp A carma_planning_msgs::srv::GetEmergencyRoute::Response with fields populated to indicate whether the route
-     * file provided in config_.emergency_route_file_path was properly processed by this node, and to provide the name of the
-     * Emergency Resonse Vehicle's route.
-     */
-    void getEmergencyRouteCallback(
-      std::shared_ptr<rmw_request_id_t>, 
-      carma_planning_msgs::srv::GetEmergencyRoute::Request::SharedPtr req, 
-      carma_planning_msgs::srv::GetEmergencyRoute::Response::SharedPtr resp);
-
-    /**
      * \brief Service callback for a service call that indicates the Emergency Response Vehicle has arrived at its destination.
      * Service is called by the Emergency Response Web UI Widget, and results in this plugin clearing its route_destination_points_
-     * so that future route destination points will no be included in the broadcasted BSMs. Additionally, route_final_destination_name_
-     * is cleared as well.
+     * so that future route destination points will no be included in the broadcasted BSMs.
      * \param req An empty std_srvs::srv::Trigger::Request.
      * \param resp A std_srvs::srv::Trigger::Response with the 'success' field set to true.
      * Emergency Resonse Vehicle's route.

--- a/carma-messenger-core/emergency_response_vehicle_plugin/include/emergency_response_vehicle_plugin/emergency_response_vehicle_plugin_node.hpp
+++ b/carma-messenger-core/emergency_response_vehicle_plugin/include/emergency_response_vehicle_plugin/emergency_response_vehicle_plugin_node.hpp
@@ -164,7 +164,7 @@ namespace emergency_response_vehicle_plugin
     /**
      * \brief Service callback for a service call that indicates the Emergency Response Vehicle has arrived at its destination.
      * Service is called by the Emergency Response Web UI Widget, and results in this plugin clearing its route_destination_points_
-     * so that future route destination points will no be included in the broadcasted BSMs.
+     * so that future route destination points will not be included in regional extension of the BSMs generated within generateBSM().
      * \param req An empty std_srvs::srv::Trigger::Request.
      * \param resp A std_srvs::srv::Trigger::Response with the 'success' field set to true.
      * Emergency Resonse Vehicle's route.

--- a/carma-messenger-core/emergency_response_vehicle_plugin/package.xml
+++ b/carma-messenger-core/emergency_response_vehicle_plugin/package.xml
@@ -29,7 +29,6 @@
   <depend>rclcpp</depend>
   <depend>carma_ros2_utils</depend>
   <depend>rclcpp_components</depend>
-  <depend>carma_planning_msgs</depend>
   <depend>carma_v2x_msgs</depend>
   <depend>carma_msgs</depend>
   <depend>j2735_v2x_msgs</depend>

--- a/carma-messenger-core/emergency_response_vehicle_plugin/test/test_emergency_response_vehicle_plugin.cpp
+++ b/carma-messenger-core/emergency_response_vehicle_plugin/test/test_emergency_response_vehicle_plugin.cpp
@@ -212,14 +212,6 @@ namespace emergency_response_vehicle_plugin{
         worker_node->config_.enable_emergency_response_vehicle_plugin = true;
         worker_node->activate();  //Call activate state transition to get not read for runtime
 
-        // Verify that getEmergencyRouteCallback() response is not successful since a route has not been loaded by the plugin yet
-        auto req = std::make_shared<carma_planning_msgs::srv::GetEmergencyRoute::Request>();
-        auto resp = std::make_shared<carma_planning_msgs::srv::GetEmergencyRoute::Response>();
-        auto header_srv = std::make_shared<rmw_request_id_t>();
-        worker_node->getEmergencyRouteCallback(header_srv, req, resp);
-
-        ASSERT_EQ(resp->is_successful, false);
-
         // Provide file path to getRouteDestinationPointsFromFile() to extract route destination points
         worker_node->loadRouteDestinationPointsFromFile("../../install_ros2/emergency_response_vehicle_plugin/share/emergency_response_vehicle_plugin/resource/example_route.csv");
 
@@ -235,18 +227,7 @@ namespace emergency_response_vehicle_plugin{
         ASSERT_NEAR(worker_node->route_destination_points_[2].longitude, -77.14527, 0.1);
         ASSERT_NEAR(worker_node->route_destination_points_[2].latitude, 38.95696, 0.1);
 
-        ASSERT_EQ(worker_node->route_final_destination_name_, "FINAL-DEST");
-
-        // Verify that getEmergencyRouteCallback() response is successful (and a route name is provided) now that a route has been loaded by the plugin
-        auto req2 = std::make_shared<carma_planning_msgs::srv::GetEmergencyRoute::Request>();
-        auto resp2 = std::make_shared<carma_planning_msgs::srv::GetEmergencyRoute::Response>();
-        auto header_srv2 = std::make_shared<rmw_request_id_t>();
-        worker_node->getEmergencyRouteCallback(header_srv2, req2, resp2);
-
-        ASSERT_EQ(resp2->is_successful, true);
-        ASSERT_EQ(resp2->route_name, "FINAL-DEST");
-
-        // Verify that arrivedAtEmergencyDestination() response is successful and that plugin's route member objects are cleared
+        // Verify that arrivedAtEmergencyDestination() response is successful and that plugin's route_destination_points_ member object is cleared
         auto req3 = std::make_shared<std_srvs::srv::Trigger::Request>();
         auto resp3 = std::make_shared<std_srvs::srv::Trigger::Response>();
         auto header_srv3 = std::make_shared<rmw_request_id_t>();
@@ -254,7 +235,6 @@ namespace emergency_response_vehicle_plugin{
 
         ASSERT_EQ(resp3->success, true);
         ASSERT_EQ(worker_node->route_destination_points_.size(), 0);
-        ASSERT_EQ(worker_node->route_final_destination_name_, "");
 
         worker_node->handle_on_shutdown();
     }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR removes support for the emergency_response_vehicle_plugin's /get_emergency_route service callback, which originally included the name of the Emergency Response Vehicle's (ERV's) route destination in the service response. This change is required because the Emergency Response UI no longer calls the /get_emergency_route service to obtain the name of the ERV's route, since the route name is no longer displayed to the user. Instead, due to PR #177, the Emergency Response Web UI displays the ERV's current location and future route destination points on an interactive map.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->
In support of [CARMA Messenger Issue #173](https://github.com/usdot-fhwa-stol/carma-messenger/issues/173) and [CARMA Platform Issue #2031](https://github.com/usdot-fhwa-stol/carma-platform/issues/2031)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This service is no longer required (as described above), so the service callback function and supporting code (including unit tests) are no longer needed, so they have been removed.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built and unit tested.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
