### PR TITLE
Update generated BSM in emergency_response_vehicle_plugin to set response_type to 'Emergency' in Part II content when ERV is actively responding to an emergency

### DIFF
--- a/carma-messenger-core/emergency_response_vehicle_plugin/src/emergency_response_vehicle_plugin_node.cpp
+++ b/carma-messenger-core/emergency_response_vehicle_plugin/src/emergency_response_vehicle_plugin_node.cpp
@@ -305,7 +305,7 @@ namespace emergency_response_vehicle_plugin
     bsm_msg.core_data.presence_vector |= carma_v2x_msgs::msg::BSMCoreData::SPEED_AVAILABLE;
     bsm_msg.core_data.speed = current_velocity_;
 
-    // Set lights status and/or siren status
+    // Set lights status, siren status, and emergency response type as necessary
     if(emergency_lights_active_ || emergency_sirens_active_){
       bsm_msg.presence_vector |= carma_v2x_msgs::msg::BSM::HAS_PART_II;
 
@@ -322,6 +322,12 @@ namespace emergency_response_vehicle_plugin
 
       if(emergency_lights_active_){
         part_ii_special.special_vehicle_extensions.vehicle_alerts.lights_use.lightbar_in_use = j2735_v2x_msgs::msg::LightbarInUse::IN_USE;
+      }
+
+      // Update BSM to indicate that ERV is actively responding to an emergency if sirens and lights are active at least one future route destination point exists
+      if(emergency_sirens_active_ && emergency_lights_active_ && !route_destination_points_.empty()){
+        part_ii_special.special_vehicle_extensions.vehicle_alerts.presence_vector |= j2735_v2x_msgs::msg::EmergencyDetails::HAS_RESPONSE_TYPE;
+        part_ii_special.special_vehicle_extensions.vehicle_alerts.response_type.response_type = j2735_v2x_msgs::msg::ResponseType::EMERGENCY;
       }
 
       bsm_msg.part_ii.push_back(part_ii_special);

--- a/carma-messenger-core/emergency_response_vehicle_plugin/test/test_emergency_response_vehicle_plugin.cpp
+++ b/carma-messenger-core/emergency_response_vehicle_plugin/test/test_emergency_response_vehicle_plugin.cpp
@@ -163,6 +163,7 @@ namespace emergency_response_vehicle_plugin{
         ASSERT_TRUE(bsm_msg.part_ii[0].special_vehicle_extensions.presence_vector && carma_v2x_msgs::msg::SpecialVehicleExtensions::HAS_VEHICLE_ALERTS);
         ASSERT_EQ(bsm_msg.part_ii[0].special_vehicle_extensions.vehicle_alerts.siren_use.siren_in_use, j2735_v2x_msgs::msg::SirenInUse::IN_USE);
         ASSERT_EQ(bsm_msg.part_ii[0].special_vehicle_extensions.vehicle_alerts.lights_use.lightbar_in_use, j2735_v2x_msgs::msg::LightbarInUse::UNAVAILABLE);
+        ASSERT_EQ(bsm_msg.part_ii[0].special_vehicle_extensions.vehicle_alerts.response_type.response_type, j2735_v2x_msgs::msg::ResponseType::NOT_IN_USE_OR_NOT_EQUIPPED);
 
         // Verify BSM's Regional Extension Content
         ASSERT_TRUE(bsm_msg.presence_vector && carma_v2x_msgs::msg::BSM::HAS_REGIONAL);
@@ -191,6 +192,7 @@ namespace emergency_response_vehicle_plugin{
 
         ASSERT_EQ(bsm_msg.part_ii[0].special_vehicle_extensions.vehicle_alerts.siren_use.siren_in_use, j2735_v2x_msgs::msg::SirenInUse::UNAVAILABLE);
         ASSERT_EQ(bsm_msg.part_ii[0].special_vehicle_extensions.vehicle_alerts.lights_use.lightbar_in_use, j2735_v2x_msgs::msg::LightbarInUse::IN_USE);
+        ASSERT_EQ(bsm_msg.part_ii[0].special_vehicle_extensions.vehicle_alerts.response_type.response_type, j2735_v2x_msgs::msg::ResponseType::NOT_IN_USE_OR_NOT_EQUIPPED);
 
         // Update statuses of lights and sirens (again) and regenerate BSM
         worker_node->emergency_lights_active_ = true;
@@ -200,6 +202,8 @@ namespace emergency_response_vehicle_plugin{
 
         ASSERT_EQ(bsm_msg.part_ii[0].special_vehicle_extensions.vehicle_alerts.siren_use.siren_in_use, j2735_v2x_msgs::msg::SirenInUse::IN_USE);
         ASSERT_EQ(bsm_msg.part_ii[0].special_vehicle_extensions.vehicle_alerts.lights_use.lightbar_in_use, j2735_v2x_msgs::msg::LightbarInUse::IN_USE);
+        ASSERT_EQ(bsm_msg.part_ii[0].special_vehicle_extensions.vehicle_alerts.presence_vector, j2735_v2x_msgs::msg::EmergencyDetails::HAS_RESPONSE_TYPE);
+        ASSERT_EQ(bsm_msg.part_ii[0].special_vehicle_extensions.vehicle_alerts.response_type.response_type, j2735_v2x_msgs::msg::ResponseType::EMERGENCY);
 
         worker_node->handle_on_shutdown();
     }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR includes a small fix within emergency_response_vehicle_plugin's `generateBSM()` function to set the 'response_type' field within a BSM's Special Vehicle Extensions Part II content to 'EMERGENCY' when the ERV's emergency lights are active, its sirens are active, and the plugin has future route destination points stored in its route_destination_points_ member object. This functionality was included in the detailed design of this plugin, but was missed during initial implementation.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->
#179 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This BSM Part II field must be set appropriately to enable V2XHub to recognize the BSM as being from an active ERV, and begin the message-forwarding process to other V2XHub instances along the ERV's future route.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests updated and are passing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
