### PR TITLE
Fix emergency_response_vehicle_plugin by enabling it to properly include an ERV's future route destination points in published BSMs

### DIFF
--- a/carma-messenger-core/emergency_response_vehicle_plugin/config/parameters.yaml
+++ b/carma-messenger-core/emergency_response_vehicle_plugin/config/parameters.yaml
@@ -19,7 +19,7 @@ emergency_route_file_name : "DEFAULT-FILE-NAME.csv"
 
 # Int: The listening port that this node’s UDP socket will bind to in order to receive data related to the status 
 #      of the ERV’s emergency sirens and lights.
-listening_port : 1610
+listening_port : 5005
 
 # Int: The BSM message ID for the Emergency Response Vehicle. The value will be converted to a 4 element array of uint8_t
 #      where each byte of the parameter becomes one element of the array.

--- a/carma-messenger-core/emergency_response_vehicle_plugin/include/emergency_response_vehicle_plugin/emergency_response_vehicle_plugin_config.hpp
+++ b/carma-messenger-core/emergency_response_vehicle_plugin/include/emergency_response_vehicle_plugin/emergency_response_vehicle_plugin_config.hpp
@@ -40,7 +40,7 @@ namespace emergency_response_vehicle_plugin
 
     std::string route_file_folder = "DEFAULT-FOLDER-PATH";           // The path to the directoy on the host PC that contains the .csv file with the ERV's route destination points. 
 
-    int listening_port = 1610;                                       // The listening port that this node’s UDP socket will bind to in order to receive data related to the status 
+    int listening_port = 5005;                                       // The listening port that this node’s UDP socket will bind to in order to receive data related to the status 
                                                                      // of the ERV’s emergency sirens and lights.
 
     int bsm_message_id = 8;                                          // The BSM message ID for the Emergency Response Vehicle. The value will be converted to a 4 element array of uint8_t

--- a/carma-messenger-core/emergency_response_vehicle_plugin/src/emergency_response_vehicle_plugin_node.cpp
+++ b/carma-messenger-core/emergency_response_vehicle_plugin/src/emergency_response_vehicle_plugin_node.cpp
@@ -335,6 +335,8 @@ namespace emergency_response_vehicle_plugin
 
     // Set route destination points
     if(!route_destination_points_.empty()){
+      bsm_msg.presence_vector |= carma_v2x_msgs::msg::BSM::HAS_REGIONAL;
+
       // Create BSM regional extension that ERV's route destination points will be added to
       carma_v2x_msgs::msg::BSMRegionalExtension regional_ext;
       regional_ext.regional_extension_id = carma_v2x_msgs::msg::BSMRegionalExtension::ROUTE_DESTINATIONS;

--- a/carma-messenger-core/emergency_response_vehicle_plugin/test/test_emergency_response_vehicle_plugin.cpp
+++ b/carma-messenger-core/emergency_response_vehicle_plugin/test/test_emergency_response_vehicle_plugin.cpp
@@ -149,15 +149,15 @@ namespace emergency_response_vehicle_plugin{
         // Verify contents of BSM's core_data
         ASSERT_EQ(worker_node->bsm_id_string_, "09000000");
         ASSERT_EQ(bsm_msg.core_data.msg_count, 127);
-        ASSERT_TRUE(bsm_msg.core_data.presence_vector && carma_v2x_msgs::msg::BSMCoreData::LATITUDE_AVAILABLE);
+        ASSERT_TRUE(bsm_msg.core_data.presence_vector & carma_v2x_msgs::msg::BSMCoreData::LATITUDE_AVAILABLE);
         ASSERT_NEAR(bsm_msg.core_data.latitude, 38.95612, 0.1);
-        ASSERT_TRUE(bsm_msg.core_data.presence_vector && carma_v2x_msgs::msg::BSMCoreData::LONGITUDE_AVAILABLE);
+        ASSERT_TRUE(bsm_msg.core_data.presence_vector & carma_v2x_msgs::msg::BSMCoreData::LONGITUDE_AVAILABLE);
         ASSERT_NEAR(bsm_msg.core_data.longitude, -77.15101, 0.1);
-        ASSERT_TRUE(bsm_msg.core_data.presence_vector && carma_v2x_msgs::msg::BSMCoreData::SPEED_AVAILABLE);
+        ASSERT_TRUE(bsm_msg.core_data.presence_vector & carma_v2x_msgs::msg::BSMCoreData::SPEED_AVAILABLE);
         ASSERT_NEAR(bsm_msg.core_data.speed, 10.0, 0.1);
 
         // Verify BSM's Part II Content
-        ASSERT_TRUE(bsm_msg.presence_vector && carma_v2x_msgs::msg::BSM::HAS_PART_II);
+        ASSERT_TRUE(bsm_msg.presence_vector & carma_v2x_msgs::msg::BSM::HAS_PART_II);
         ASSERT_EQ(bsm_msg.part_ii.size(), 1);
         ASSERT_EQ(bsm_msg.part_ii[0].part_ii_id, carma_v2x_msgs::msg::BSMPartIIExtension::SPECIAL_VEHICLE_EXT);
         ASSERT_TRUE(bsm_msg.part_ii[0].special_vehicle_extensions.presence_vector && carma_v2x_msgs::msg::SpecialVehicleExtensions::HAS_VEHICLE_ALERTS);
@@ -166,7 +166,7 @@ namespace emergency_response_vehicle_plugin{
         ASSERT_EQ(bsm_msg.part_ii[0].special_vehicle_extensions.vehicle_alerts.response_type.response_type, j2735_v2x_msgs::msg::ResponseType::NOT_IN_USE_OR_NOT_EQUIPPED);
 
         // Verify BSM's Regional Extension Content
-        ASSERT_TRUE(bsm_msg.presence_vector && carma_v2x_msgs::msg::BSM::HAS_REGIONAL);
+        ASSERT_TRUE(bsm_msg.presence_vector & carma_v2x_msgs::msg::BSM::HAS_REGIONAL);
         ASSERT_EQ(bsm_msg.regional.size(), 1);
         ASSERT_EQ(bsm_msg.regional[0].regional_extension_id, carma_v2x_msgs::msg::BSMRegionalExtension::ROUTE_DESTINATIONS);
         ASSERT_EQ(bsm_msg.regional[0].route_destination_points.size(), 3);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR includes a couple of minor fixes to the emergency_response_vehicle_plugin in CARMA Messenger. Specifically, a bug is fixed in which `&&` was incorrectly being used for 'bitwise AND' operations, rather than the correct `&` in emergency_response_vehicle_plugin unit tests. Additionally, the BSM presence vector is not properly set to indicate that a regional extension is present when it is included in the BSM (this regional extension is used to include the ERV's future route destination points). Fixing this bug will enable to the plugin to properly include the ERV's future route destination points in its published BSMs. 

Additionally, this PR updates the default UDP listening port (on which it listens to incoming UDP packets that describe the activation status of an ERV's emergency lights and sirens) to '5005' to match the networking setup currently configured in the Chevy Tahoe. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->
Issue #188 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The bitwise operator update fixes a bug that is required to properly include the ERV's future route destination points in its broadcasted BSMs.

The listening port update is more of a convenience update to match the default setup in the team's vehicle used for CARMA Messenger testing.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tested.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
