### PR TITLE
Adjust the WARNING message in web ui for CARMA messenger to be larger

### DIFF
--- a/carma-messenger-ui/website/widgets/emergencyResponse/widget.css
+++ b/carma-messenger-ui/website/widgets/emergencyResponse/widget.css
@@ -49,3 +49,7 @@
 #emergencyAlert{
     z-index: 999;
 }
+
+#emergencyAlertMsg{
+    font-size: larger;
+}

--- a/carma-messenger-ui/website/widgets/emergencyResponse/widget.js
+++ b/carma-messenger-ui/website/widgets/emergencyResponse/widget.js
@@ -189,7 +189,7 @@ setInterval(() => {
     }
     $("#emergencyAlert").removeClass("show");
     document.getElementById('audioAlert3').pause();
-}, 5000);
+}, 10000);
 
 //Create alert element
 var createAlertDiv = (message) => {


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Adjust the WARNING message in web ui for CARMA messenger to be larger
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-messenger/issues/195
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Motivation and Context
Freight integration testing
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
NA
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
