### PR TITLE
[cpp_message] Fix segmentation fault when encoding SDSM messages

### DIFF
--- a/carma-messenger-core/cpp_message/src/SDSM_Message.cpp
+++ b/carma-messenger-core/cpp_message/src/SDSM_Message.cpp
@@ -61,6 +61,13 @@ namespace cpp_message
             message->value.choice.SensorDataSharingMessage.msgCnt = plainMessage.msg_cnt.msg_cnt;
         }
 
+        if (const auto id_size{std::size(plainMessage.source_id.id)}; id_size != 4U)
+        {
+            RCLCPP_ERROR_STREAM(node_logging_->get_logger(),
+                                "Cannot encode SDSM message: 'source_id' size is "
+                                    << id_size << " bytes (must be 4)");
+            return std::nullopt;
+        }
 
         // TemporaryID | sourceID - source_id
         uint8_t temp_id_content[4] ={0};


### PR DESCRIPTION
# PR Details
## Description

This PR fixes a segmentation fault during SDSM encoding caused by trying to copy the message's source ID. The `TemporaryID.msg`'s `id` field gets implemented as a `std::vector<std::uint8_t>`, which is not guaranteed to have any elements. The SDSM encoding function assumes that the `SensorDataSharingMessage.msg`'s `source_id` field has 4 elements.

This PR adds a size check before copying the data.

## Related GitHub Issue

## Related Jira Key

Closes [CDAR-775](https://usdot-carma.atlassian.net/browse/CDAR-775)

## Motivation and Context

Bug fix

## How Has This Been Tested?

Manually in integration testing

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-775]: https://usdot-carma.atlassian.net/browse/CDAR-775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ