### PR TITLE
updated to reflect new j2735 and j3224 package names

### DIFF
--- a/carma-messenger-core/j2735_convertor/include/j2735_convertor/control_message_convertor.hpp
+++ b/carma-messenger-core/j2735_convertor/include/j2735_convertor/control_message_convertor.hpp
@@ -27,13 +27,13 @@ namespace j2735_convertor
 /**
  * @brief Namespace responsible for converting j2735 style Geofence control messages to CARMA usable control messages
  *
- * Handles conversion between ControlMessages in the j2735_msgs and cav_msgs packages.
+ * Handles conversion between ControlMessages in the j2735_v2x_msgs and cav_msgs packages.
  * Unit conversions and presence flags are also handled
  */
 namespace geofence_control
 {
 ////
-// Convert j2735_msgs to cav_msgs
+// Convert j2735_v2x_msgs to cav_msgs
 ////
 
 /**
@@ -127,7 +127,7 @@ void convert(const j2735_v2x_msgs::msg::TrafficControlParams& in_msg, carma_v2x_
 void convert(const j2735_v2x_msgs::msg::TrafficControlSchedule& in_msg, carma_v2x_msgs::msg::TrafficControlSchedule& out_msg);
 
 ////
-// Convert cav_msgs to j2735_msgs
+// Convert cav_msgs to j2735_v2x_msgs
 ////
 
 

--- a/carma-messenger-core/j2735_convertor/include/j2735_convertor/control_request_convertor.hpp
+++ b/carma-messenger-core/j2735_convertor/include/j2735_convertor/control_request_convertor.hpp
@@ -29,13 +29,13 @@ namespace j2735_convertor
 /**
  * @brief Namespace responsible for converting j2735 style Geofence request messages to CARMA usable control messages
  *
- * Handles conversion between ControlRequest in the j2735_msgs and cav_msgs packages.
+ * Handles conversion between ControlRequest in the j2735_v2x_msgs and cav_msgs packages.
  * Unit conversions and presence flags are also handled
  */
 namespace geofence_request
 {
 ////
-// Convert j2735_msgs to cav_msgs
+// Convert j2735_v2x_msgs to cav_msgs
 ////
 
 /**
@@ -81,7 +81,7 @@ void convert(const j2735_v2x_msgs::msg::TrafficControlRequestV01& in_msg, carma_
 void convert(const j2735_v2x_msgs::msg::TrafficControlRequest& in_msg, carma_v2x_msgs::msg::TrafficControlRequest& out_msg);
 
 ////
-// Convert cav_msgs to j2735_msgs
+// Convert cav_msgs to j2735_v2x_msgs
 ////
 
 

--- a/carma-messenger-core/j2735_convertor/include/j2735_convertor/j2735_convertor_node.hpp
+++ b/carma-messenger-core/j2735_convertor/include/j2735_convertor/j2735_convertor_node.hpp
@@ -37,10 +37,10 @@ namespace j2735_convertor
 
   /**
    * @class j2735_convertor::Node
-   * @brief Is the class responsible for conversion of j2735_msgs to cav_msgs
+   * @brief Is the class responsible for conversion of j2735_v2x_msgs to cav_msgs
    *
-   * The J2735Convertor is a ROS Node which subscribes to topics containing messages from the j2735_msgs package.
-   * The j2735_msgs are then converted to cav_msgs types including any necessary unit conversions.
+   * The J2735Convertor is a ROS Node which subscribes to topics containing messages from the j2735_v2x_msgs package.
+   * The j2735_v2x_msgs are then converted to cav_msgs types including any necessary unit conversions.
    *
    * Each j2735 topic has its own thread for processing. This will help prevent larger message types like Map from
    * blocking small high frequency message types like BSMs.

--- a/carma-messenger-core/j2735_convertor/include/j2735_convertor/map_convertor.hpp
+++ b/carma-messenger-core/j2735_convertor/include/j2735_convertor/map_convertor.hpp
@@ -30,7 +30,7 @@ namespace j2735_convertor
  * @class MAPConvertor
  * @brief Is the class responsible for converting J2735 Maps to CARMA usable Mapss
  *
- * Handles conversion between Map messages in the j2735_msgs and cav_msgs packages.
+ * Handles conversion between Map messages in the j2735_v2x_msgs and cav_msgs packages.
  * Unit conversions are handled
  * Note: The concept of map Zoom is not accounted for in these conversions
  */

--- a/carma-messenger-core/j2735_convertor/include/j2735_convertor/psm_convertor.hpp
+++ b/carma-messenger-core/j2735_convertor/include/j2735_convertor/psm_convertor.hpp
@@ -32,7 +32,7 @@ namespace j2735_convertor
  * @class PSMConvertor
  * @brief Is the class responsible for converting J2735 PSMs to CARMA usable PSMs
  *
- * Handles conversion between PSMs in the j2735_msgs and cav_msgs packages.
+ * Handles conversion between PSMs in the j2735_v2x_msgs and cav_msgs packages.
  * Unit conversions and presence flags are also handled
  */
 class PSMConvertor
@@ -60,7 +60,7 @@ class PSMConvertor
 
   private:
     ////
-    // Convert j2735_msgs to cav_msgs
+    // Convert j2735_v2x_msgs to cav_msgs
     ////
 
     /**
@@ -144,7 +144,7 @@ class PSMConvertor
      static void convert(const j2735_v2x_msgs::msg::Velocity& in_msg, carma_v2x_msgs::msg::Velocity& out_msg);
 
     ////
-    // Convert cav_msgs to j2735_msgs
+    // Convert cav_msgs to j2735_v2x_msgs
     ////
 
     /**

--- a/carma-messenger-core/j2735_convertor/include/j2735_convertor/sdsm_convertor.hpp
+++ b/carma-messenger-core/j2735_convertor/include/j2735_convertor/sdsm_convertor.hpp
@@ -61,7 +61,7 @@ public:
 
 private:
     ////
-    // Convert j2735_msgs
+    // Convert j2735_v2x_msgs
     ////
 
     /**
@@ -248,7 +248,7 @@ private:
 
 
     ////
-    // Convert j3224_msgs
+    // Convert j3224_v2x_msgs
     ////
 
     // static void convert(const j3224_v2x_msgs::msg::DetectedObjectList& in_msg, carma_v2x_msgs::msg::DetectedObjectList& out_msg);

--- a/carma-messenger-core/j2735_convertor/include/j2735_convertor/spat_convertor.hpp
+++ b/carma-messenger-core/j2735_convertor/include/j2735_convertor/spat_convertor.hpp
@@ -30,7 +30,7 @@ namespace j2735_convertor
  * @class SPATConvertor
  * @brief Is the class responsible for converting J2735 SPATs to CARMA usable SPATs
  *
- * Handles conversion between Map messages in the j2735_msgs and cav_msgs packages.
+ * Handles conversion between Map messages in the j2735_v2x_msgs and cav_msgs packages.
  * Unit conversions are handled
  */
 class SPATConvertor

--- a/carma-messenger-core/j2735_convertor/include/j2735_convertor/units.hpp
+++ b/carma-messenger-core/j2735_convertor/include/j2735_convertor/units.hpp
@@ -19,7 +19,7 @@ namespace j2735_convertor
 {
 /**
  * Defined the units namespace which contains many unit conversion factors
- * These are primarily meant to be used in conversions between j2735_msgs and cav_msgs
+ * These are primarily meant to be used in conversions between j2735_v2x_msgs and cav_msgs
  * 
  * New units should follow the LSB unit guidelines given by the appropriate SAE standard
  * For instance, "LSB units of 0.01 degrees per second" would equate to "HUNDREDTH_DEG_PER_S"

--- a/carma-messenger-core/j2735_convertor/include/j2735_convertor/value_convertor.hpp
+++ b/carma-messenger-core/j2735_convertor/include/j2735_convertor/value_convertor.hpp
@@ -29,7 +29,7 @@ namespace j2735_convertor
 {
 /**
  * @class ValueConvertor
- * @brief Class responsible for converting between discrete values in j2735_msgs and cav_msgs
+ * @brief Class responsible for converting between discrete values in j2735_v2x_msgs and cav_msgs
  *
  * Provides templated functions which will perform unit conversions and casting.
  * Additionally, conversion between presence vectors and unavailability values is supported.

--- a/carma-messenger-core/j2735_convertor/src/bsm_convertor.cpp
+++ b/carma-messenger-core/j2735_convertor/src/bsm_convertor.cpp
@@ -834,7 +834,7 @@ void BSMConvertor::convert(const j2735_v2x_msgs::msg::BSM& in_msg, carma_v2x_msg
 }
 
 ////
-// Convert carma_v2x_msgs to j2735_msgs
+// Convert carma_v2x_msgs to j2735_v2x_msgs
 ////
 
 void BSMConvertor::convert(const std::vector<carma_v2x_msgs::msg::Position3D>& in_msg, std::vector<j2735_v2x_msgs::msg::Position3D>& out_msg)

--- a/carma-messenger-core/j2735_convertor/src/control_message_convertor.cpp
+++ b/carma-messenger-core/j2735_convertor/src/control_message_convertor.cpp
@@ -23,7 +23,7 @@ namespace j2735_convertor
 namespace geofence_control
 {
 ////
-// Convert j2735_msgs to cav_msgs
+// Convert j2735_v2x_msgs to cav_msgs
 ////
 
 void convert(const j2735_v2x_msgs::msg::DailySchedule& in_msg, carma_v2x_msgs::msg::DailySchedule& out_msg)
@@ -189,7 +189,7 @@ void convert(const j2735_v2x_msgs::msg::TrafficControlMessage& in_msg, carma_v2x
 void convert(const j2735_v2x_msgs::msg::TrafficControlMessageV01& in_msg, carma_v2x_msgs::msg::TrafficControlMessageV01& out_msg)
 {
   // # reqid ::= Id64b
-  // j2735_msgs/Id64b reqid
+  // j2735_v2x_msgs/Id64b reqid
   out_msg.reqid = in_msg.reqid;
 
   // # reqseq ::= INTEGER (0..255)
@@ -205,7 +205,7 @@ void convert(const j2735_v2x_msgs::msg::TrafficControlMessageV01& in_msg, carma_
   out_msg.msgnum = in_msg.msgnum;
 
   // # id Id128b, -- unique traffic control id
-  // j2735_msgs/Id128b id
+  // j2735_v2x_msgs/Id128b id
   out_msg.id = in_msg.id;
 
   // # updated EpochMins
@@ -213,7 +213,7 @@ void convert(const j2735_v2x_msgs::msg::TrafficControlMessageV01& in_msg, carma_
   out_msg.updated = rclcpp::Time(in_msg.updated * units::SEC_PER_MIN, 0);
 
   // # package [0] TrafficControlPackage OPTIONAL, -- related traffic control ids
-  // j2735_msgs/TrafficControlPackage package
+  // j2735_v2x_msgs/TrafficControlPackage package
   // bool package_exists
   out_msg.package_exists = in_msg.package_exists;
   if(out_msg.package_exists)
@@ -242,7 +242,7 @@ void convert(const j2735_v2x_msgs::msg::TrafficControlMessageV01& in_msg, carma_
 
 void convert(const j2735_v2x_msgs::msg::TrafficControlParams& in_msg, carma_v2x_msgs::msg::TrafficControlParams& out_msg)
 {
-  // j2735_msgs/TrafficControlVehClass[] vclasses
+  // j2735_v2x_msgs/TrafficControlVehClass[] vclasses
   out_msg.vclasses = in_msg.vclasses;
   
   // # schedule TrafficControlSchedule
@@ -307,7 +307,7 @@ void convert(const j2735_v2x_msgs::msg::TrafficControlSchedule& in_msg, carma_v2
 }
 
 ////
-// Convert cav_msgs to j2735_msgs
+// Convert cav_msgs to j2735_v2x_msgs
 ////
 
 void convert(const carma_v2x_msgs::msg::DailySchedule& in_msg, j2735_v2x_msgs::msg::DailySchedule& out_msg)
@@ -466,7 +466,7 @@ void convert(const carma_v2x_msgs::msg::TrafficControlMessage& in_msg, j2735_v2x
 void convert(const carma_v2x_msgs::msg::TrafficControlMessageV01& in_msg, j2735_v2x_msgs::msg::TrafficControlMessageV01& out_msg)
 {
   // # reqid ::= Id64b
-  // j2735_msgs/Id64b reqid
+  // j2735_v2x_msgs/Id64b reqid
   out_msg.reqid = in_msg.reqid;
 
   // # reqseq ::= INTEGER (0..255)
@@ -482,7 +482,7 @@ void convert(const carma_v2x_msgs::msg::TrafficControlMessageV01& in_msg, j2735_
   out_msg.msgnum = in_msg.msgnum;
 
   // # id Id128b, -- unique traffic control id
-  // j2735_msgs/Id128b id
+  // j2735_v2x_msgs/Id128b id
   out_msg.id = in_msg.id;
 
   // # updated EpochMins
@@ -491,7 +491,7 @@ void convert(const carma_v2x_msgs::msg::TrafficControlMessageV01& in_msg, j2735_
   out_msg.updated = updated.seconds() / units::SEC_PER_MIN;
 
   // # package [0] TrafficControlPackage OPTIONAL, -- related traffic control ids
-  // j2735_msgs/TrafficControlPackage package
+  // j2735_v2x_msgs/TrafficControlPackage package
   // bool package_exists
   out_msg.package_exists = in_msg.package_exists;
   if(out_msg.package_exists)
@@ -520,7 +520,7 @@ void convert(const carma_v2x_msgs::msg::TrafficControlMessageV01& in_msg, j2735_
 
 void convert(const carma_v2x_msgs::msg::TrafficControlParams& in_msg, j2735_v2x_msgs::msg::TrafficControlParams& out_msg)
 {
-  // j2735_msgs/TrafficControlVehClass[] vclasses
+  // j2735_v2x_msgs/TrafficControlVehClass[] vclasses
   out_msg.vclasses = in_msg.vclasses;
   
   // # schedule TrafficControlSchedule

--- a/carma-messenger-core/j2735_convertor/src/control_request_convertor.cpp
+++ b/carma-messenger-core/j2735_convertor/src/control_request_convertor.cpp
@@ -23,7 +23,7 @@ namespace j2735_convertor
 namespace geofence_request
 {
 /////
-// Convert j2735_msgs to cav_msgs
+// Convert j2735_v2x_msgs to cav_msgs
 /////
 
 void convert(const j2735_v2x_msgs::msg::OffsetPoint& in_msg, carma_v2x_msgs::msg::OffsetPoint& out_msg,const int8_t scale)
@@ -47,7 +47,7 @@ void convert(const j2735_v2x_msgs::msg::TrafficControlBounds& in_msg, carma_v2x_
 void convert(const j2735_v2x_msgs::msg::TrafficControlRequestV01& in_msg, carma_v2x_msgs::msg::TrafficControlRequestV01& out_msg)
 {
   // # reqid ::= Id64b
-  // j2735_msgs/Id64b reqid
+  // j2735_v2x_msgs/Id64b reqid
   out_msg.reqid = in_msg.reqid;
 
   // # reqseq ::= INTEGER (0..255)
@@ -84,7 +84,7 @@ void convert(const j2735_v2x_msgs::msg::TrafficControlRequest& in_msg, carma_v2x
 }
 
 ////
-// Convert cav_msgs to j2735_msgs
+// Convert cav_msgs to j2735_v2x_msgs
 ////
 
 // The use case for the control request is to grab large sets of geofences at once. So error under a meter is unlikely to matter
@@ -157,7 +157,7 @@ void convert(const carma_v2x_msgs::msg::TrafficControlBounds& in_msg, j2735_v2x_
 void convert(const carma_v2x_msgs::msg::TrafficControlRequestV01& in_msg, j2735_v2x_msgs::msg::TrafficControlRequestV01& out_msg)
 {
   // # reqid ::= Id64b
-  // j2735_msgs/Id64b reqid
+  // j2735_v2x_msgs/Id64b reqid
   out_msg.reqid = in_msg.reqid;
 
   // # reqseq ::= INTEGER (0..255)

--- a/carma-messenger-core/j2735_convertor/src/psm_convertor.cpp
+++ b/carma-messenger-core/j2735_convertor/src/psm_convertor.cpp
@@ -308,7 +308,7 @@ void PSMConvertor::convert(const j2735_v2x_msgs::msg::PSM& in_msg, carma_v2x_msg
 }
 
 ////
-// Convert cav_msgs to j2735_msgs
+// Convert cav_msgs to j2735_v2x_msgs
 ////
 
 void PSMConvertor::convert(const carma_v2x_msgs::msg::PathPrediction& in_msg, j2735_v2x_msgs::msg::PathPrediction& out_msg)

--- a/carma-messenger-core/j2735_convertor/src/sdsm_convertor.cpp
+++ b/carma-messenger-core/j2735_convertor/src/sdsm_convertor.cpp
@@ -89,7 +89,7 @@ void SDSMConvertor::convert(const carma_v2x_msgs::msg::SensorDataSharingMessage&
 
 
 ////
-// Convert j2735_msgs
+// Convert j2735_v2x_msgs
 ////
 
 
@@ -308,7 +308,7 @@ void SDSMConvertor::convert(const carma_v2x_msgs::msg::AttachmentRadius& in_msg,
 
 
 ////
-// Convert j3224_msgs
+// Convert j3224_v2x_msgs
 ////
 
 

--- a/carma-messenger-core/j2735_convertor/test/control_message_test.cpp
+++ b/carma-messenger-core/j2735_convertor/test/control_message_test.cpp
@@ -123,7 +123,7 @@ namespace j2735_convertor
     j2735_v2x_msgs::msg::TrafficControlParams in_msg;
 
     // # vclasses SEQUENCE (SIZE(1..255)) OF TrafficControlVehClass,
-    // j2735_msgs/TrafficControlVehClass[] vclasses
+    // j2735_v2x_msgs/TrafficControlVehClass[] vclasses
     j2735_v2x_msgs::msg::TrafficControlVehClass tcvc;
     for(int i = 0; i < NUM_NODES; i++)
     {
@@ -149,7 +149,7 @@ namespace j2735_convertor
   {
     j2735_v2x_msgs::msg::TrafficControlMessageV01 in_msg;
     // # reqid ::= Id64b
-    // j2735_msgs/Id64b reqid
+    // j2735_v2x_msgs/Id64b reqid
     in_msg.reqid.id = {0, 1, 2, 3, 4, 5, 6, 7};
 
     // # reqseq ::= INTEGER (0..255)
@@ -165,7 +165,7 @@ namespace j2735_convertor
     in_msg.msgnum = 0;
 
     // # id Id128b, -- unique traffic control id
-    // j2735_msgs/Id128b reqid
+    // j2735_v2x_msgs/Id128b reqid
     in_msg.id.id = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
 
     // # updated EpochMins
@@ -173,7 +173,7 @@ namespace j2735_convertor
     in_msg.updated = 1000000;
 
     // # package [0] TrafficControlPackage OPTIONAL, -- related traffic control ids
-    // j2735_msgs/TrafficControlPackage package
+    // j2735_v2x_msgs/TrafficControlPackage package
     // bool package_exists
     in_msg.package_exists = optional;
     in_msg.package.label_exists = optional;
@@ -313,7 +313,7 @@ namespace j2735_convertor
     carma_v2x_msgs::msg::TrafficControlParams in_msg;
 
     // # vclasses SEQUENCE (SIZE(1..255)) OF TrafficControlVehClass,
-    // j2735_msgs/TrafficControlVehClass[] vclasses
+    // j2735_v2x_msgs/TrafficControlVehClass[] vclasses
     j2735_v2x_msgs::msg::TrafficControlVehClass tcvc;
     for(int i = 0; i < NUM_NODES; i++)
     {
@@ -363,7 +363,7 @@ namespace j2735_convertor
     in_msg.updated = rclcpp::Time(180000, 0);
 
     // # package [0] TrafficControlPackage OPTIONAL, -- related traffic control ids
-    // j2735_msgs/TrafficControlPackage package
+    // j2735_v2x_msgs/TrafficControlPackage package
     // bool package_exists
     in_msg.package_exists = optional;
 


### PR DESCRIPTION
# PR Details
## Description

This PR renames the `j2735_msgs` and `j322_msgs` packages after these packages were merged into `j2735_v2x_msgs` and `j3224_v2x_msgs` in [carma-msgs PR #243](https://github.com/usdot-fhwa-stol/carma-msgs/pull/243).

## Related GitHub Issue

NA

## Related Jira Key

[ARC-205](https://usdot-carma.atlassian.net/browse/ARC-205)

## Motivation and Context

Old package names are outdated and no longer exist.

## How Has This Been Tested?

Only changes are comments, so testing is not required.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[ARC-205]: https://usdot-carma.atlassian.net/browse/ARC-205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ