### PR TITLE
Pinpoint Topic Remapping

### DIFF
--- a/carma-messenger-core/carma-messenger/launch/plugins.launch.py
+++ b/carma-messenger-core/carma-messenger/launch/plugins.launch.py
@@ -66,8 +66,8 @@ def generate_launch_description():
                     {'--log-level' : GetLogLevel('emergency_response_vehicle_plugin', env_log_levels) }
                 ],
                 remappings=[
-                    ("vehicle_pose", "position/gps_common_fix" ),
-                    ("velocity",     "position/velocity" ),
+                    ("vehicle_pose", "hardware_interface/gps_common_fix" ),
+                    ("velocity",     "hardware_interface/velocity" ),
                     ("outgoing_bsm", "bsm_outbound")
                 ],
                 parameters = [

--- a/carma-messenger-core/emergency_response_vehicle_plugin/config/parameters.yaml
+++ b/carma-messenger-core/emergency_response_vehicle_plugin/config/parameters.yaml
@@ -2,7 +2,7 @@
 #          the Emergency Response Vehicle's BSMs and process incoming UDP packets on the local port provided
 #          in the 'listening_port' parameter.
 # Units: N/A
-enable_emergency_response_vehicle_plugin : true
+enable_emergency_response_vehicle_plugin : false
 
 # Double: The frequency at which BSMs will be generated and published by this plugin. 
 # Units: Hz
@@ -15,7 +15,7 @@ min_distance_to_next_destination_point : 30.0
 
 # String: The name of the .csv file on the host PC that contains the pre-defined points existing along the ERV's route.
 # Units: N/A
-emergency_route_file_name : "ERV-Northbound-Middle-Lane.csv" #"ERV-Northbound-Middle-Lane.csv"
+emergency_route_file_name : "DEFAULT-FILE-NAME.csv"
 
 # Int: The listening port that this node’s UDP socket will bind to in order to receive data related to the status 
 #      of the ERV’s emergency sirens and lights.

--- a/carma-messenger-core/emergency_response_vehicle_plugin/config/parameters.yaml
+++ b/carma-messenger-core/emergency_response_vehicle_plugin/config/parameters.yaml
@@ -2,7 +2,7 @@
 #          the Emergency Response Vehicle's BSMs and process incoming UDP packets on the local port provided
 #          in the 'listening_port' parameter.
 # Units: N/A
-enable_emergency_response_vehicle_plugin : false
+enable_emergency_response_vehicle_plugin : true
 
 # Double: The frequency at which BSMs will be generated and published by this plugin. 
 # Units: Hz
@@ -15,7 +15,7 @@ min_distance_to_next_destination_point : 30.0
 
 # String: The name of the .csv file on the host PC that contains the pre-defined points existing along the ERV's route.
 # Units: N/A
-emergency_route_file_name : "DEFAULT-FILE-NAME.csv"
+emergency_route_file_name : "ERV-Northbound-Middle-Lane.csv" #"ERV-Northbound-Middle-Lane.csv"
 
 # Int: The listening port that this node’s UDP socket will bind to in order to receive data related to the status 
 #      of the ERV’s emergency sirens and lights.

--- a/carma-messenger-core/traffic_incident/launch/traffic_incident.launch.py
+++ b/carma-messenger-core/traffic_incident/launch/traffic_incident.launch.py
@@ -65,7 +65,7 @@ def generate_launch_description():
                     traffic_incident_param_file,
                 ],
                 remappings=[
-                    ("gps_common_fix", "/position/gps_common_fix"),
+                    ("gps_common_fix", "/hardware_interface/gps_common_fix"),
                 ]
             ),
         ],

--- a/carma-messenger-ui/website/widgets/eventManagement/widget.js
+++ b/carma-messenger-ui/website/widgets/eventManagement/widget.js
@@ -163,7 +163,7 @@ CarmaJS.WidgetFramework.eventManagement = (function () {
         console.log('subscribe_gps_common_fix called');
          var listenerGPS = new ROSLIB.Topic({
             ros: ros,
-            name: '/position/gps_common_fix',
+            name: '/hardware_interface/gps_common_fix',
             messageType: 'gps_common/GPSFix'
         });
 


### PR DESCRIPTION


<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This PR fixes the topic remapping for the pinpoint sensor, changing it from `/position` to `/hardware_interface`.

## Related GitHub Issue

NA

## Related Jira Key

[CAR-6063](https://usdot-carma.atlassian.net/browse/CAR-6063)

## Motivation and Context

When ported to ROS2 in [carma-torc-pinpoint-driver#46](https://github.com/usdot-fhwa-stol/carma-torc-pinpoint-driver/pull/46), the CARMA Torc Pinpoint Driver namespace was changed to `/hardware_interface` to match the rest of the CARMA drivers. This same change is needed in CARMA Messenger to connect with the Pinpoint Driver.

## How Has This Been Tested?

Tested on the Chevrolet Tahoe. Testing included:

1. Adding the above changes into the necessary docker images.
2. Running CARMA Messenger
3. Checked that CARMA Messenger subscribed to the correct topics (`/hardware_interface/gps_common_fix` and `/hardware_interface/velocity`)
4. Verified that the GPS coordinates showed up in the CARMA messenger web UI

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CAR-6063]: https://usdot-carma.atlassian.net/browse/CAR-6063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ