### PR TITLE
Fix GPS Coordinates not Showing Up in Traffic Incident Plugin

### DIFF
--- a/carma-messenger-ui/website/widgets/eventManagement/widget.js
+++ b/carma-messenger-ui/website/widgets/eventManagement/widget.js
@@ -164,7 +164,7 @@ CarmaJS.WidgetFramework.eventManagement = (function () {
          var listenerGPS = new ROSLIB.Topic({
             ros: ros,
             name: '/hardware_interface/gps_common_fix',
-            messageType: 'gps_common/GPSFix'
+            messageType: 'gps_msgs/msg/GPSFix'
         });
 
         listenerGPS.subscribe(function (message) {
@@ -534,13 +534,13 @@ CarmaJS.WidgetFramework.eventManagement = (function () {
               fieldsetNote.append(newSpanNoteDescription);
 
               var newSpanNoteUpTrack = document.createElement('span');
-              newSpanNoteUpTrack.innerHTML = "Up Track: Distance from the center of the vehicle (Taheo) to the beginning of geofence.";
+              newSpanNoteUpTrack.innerHTML = "Up Track: Distance from the center of the vehicle (Tahoe) to the beginning of geofence.";
               newSpanNoteUpTrack.id="noteUpTrackSpan";
               newSpanNoteUpTrack.className="form-label  text-align-left block margin-bottom-20px";
               fieldsetNote.append(newSpanNoteUpTrack);
 
               var newSpanNoteDownTrack = document.createElement('span');
-              newSpanNoteDownTrack.innerHTML = "Down Track: Distance between center of the vehicle (Taheo) to the center of the geofence.";
+              newSpanNoteDownTrack.innerHTML = "Down Track: Distance between center of the vehicle (Tahoe) to the center of the geofence.";
               newSpanNoteDownTrack.id="noteDownTrackSpan";
               newSpanNoteDownTrack.className="form-label text-align-left block margin-bottom-20px";
               fieldsetNote.append(newSpanNoteDownTrack);


### PR DESCRIPTION
# PR Details
## Description

This PR resolves an issue where the GPS coordinates reported by the Pinpoint device do not show up in the CARMA Messenger Traffic Incident Management plugin.

## Related GitHub Issue

NA

## Related Jira Key

[CRA-6063](https://usdot-carma.atlassian.net/browse/CAR-6063)

## Motivation and Context

This change results in the GPS coordinate being populated correctly.

## How Has This Been Tested?

Tested on the Chevy Tahoe. Confirmed that coordinates are loaded sucessfully

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
