### PR TITLE
fix: rename map to ervMap to avoid redeclaration error

### DIFF
--- a/carma-messenger-ui/website/widgets/emergencyResponse/widget.js
+++ b/carma-messenger-ui/website/widgets/emergencyResponse/widget.js
@@ -5,7 +5,7 @@ CarmaJS.registerNamespace("CarmaJS.WidgetFramework.emergencyResponse");
 var listenerAlert;
 var listenerBSM;
 //Initialize map object
-var map = null;
+var ervMap = null;
 const ERV_ROUTE_SOURCE = "erv-route-trace";
 //Initialize dataset
 var data = {
@@ -71,7 +71,7 @@ var subscribe_bsm = () => {
                     data.features.push(route_feature);
                 });
             }
-            map.getSource(ERV_ROUTE_SOURCE).setData(data);
+            ervMap.getSource(ERV_ROUTE_SOURCE).setData(data);
             if (data.features.length > 1) {
                 if (destination_pin == null) {
                     destination_pin = createMarker(data.features[data.features.length - 1].geometry.coordinates);
@@ -137,7 +137,7 @@ var createFeature = () => {
 var createMarker = ([longitude, latitude]) => {
     let marker = new mapboxgl.Marker({
         color: "#FF0000"
-    }).setLngLat([latitude, longitude]).addTo(map);
+    }).setLngLat([latitude, longitude]).addTo(ervMap);
     return marker;
 }
 
@@ -239,26 +239,26 @@ var loadMap = () => {
     mapboxgl.accessToken = "pk.eyJ1IjoiZGR1MjAyMCIsImEiOiJjbDJyeHJob2YwYnhwM2xtaG9zaDdnYTR4In0.Rh2bSS44c99BoDj2W7jjfw";
     //Default view is at TFHRC
     let default_center = [-77.150495, 38.955675];
-    map = new mapboxgl.Map({
+    ervMap = new mapboxgl.Map({
         container: 'erv-map',
         style: 'mapbox://styles/mapbox/satellite-v9',
         center: default_center,
         zoom: 17
     });
-    map.addControl(new mapboxgl.FullscreenControl());
+    ervMap.addControl(new mapboxgl.FullscreenControl());
 
     setInterval(() => {
         //Change View Point
-        map.jumpTo({ 'center': data.features[0].geometry.coordinates.length == 0 ? default_center : data.features[0].geometry.coordinates, 'zoom': 17 });
+        ervMap.jumpTo({ 'center': data.features[0].geometry.coordinates.length == 0 ? default_center : data.features[0].geometry.coordinates, 'zoom': 17 });
     }, 2000);
 
-    map.on('load', () => {
-        map.addSource(ERV_ROUTE_SOURCE, {
+    ervMap.on('load', () => {
+        ervMap.addSource(ERV_ROUTE_SOURCE, {
             'type': 'geojson',
             'data': data
         });
 
-        map.addLayer({
+        ervMap.addLayer({
             'id': ERV_ROUTE_SOURCE,
             'type': 'circle',
             'source': 'erv-route-trace',

--- a/carma-messenger-ui/website/widgets/emergencyResponse/widget.js
+++ b/carma-messenger-ui/website/widgets/emergencyResponse/widget.js
@@ -5,7 +5,7 @@ CarmaJS.registerNamespace("CarmaJS.WidgetFramework.emergencyResponse");
 var listenerAlert;
 var listenerBSM;
 //Initialize map object
-var ervMap = null;
+var erv_map = null;
 const ERV_ROUTE_SOURCE = "erv-route-trace";
 //Initialize dataset
 var data = {
@@ -71,7 +71,7 @@ var subscribe_bsm = () => {
                     data.features.push(route_feature);
                 });
             }
-            ervMap.getSource(ERV_ROUTE_SOURCE).setData(data);
+            erv_map.getSource(ERV_ROUTE_SOURCE).setData(data);
             if (data.features.length > 1) {
                 if (destination_pin == null) {
                     destination_pin = createMarker(data.features[data.features.length - 1].geometry.coordinates);
@@ -137,7 +137,7 @@ var createFeature = () => {
 var createMarker = ([longitude, latitude]) => {
     let marker = new mapboxgl.Marker({
         color: "#FF0000"
-    }).setLngLat([latitude, longitude]).addTo(ervMap);
+    }).setLngLat([latitude, longitude]).addTo(erv_map);
     return marker;
 }
 
@@ -239,26 +239,26 @@ var loadMap = () => {
     mapboxgl.accessToken = "pk.eyJ1IjoiZGR1MjAyMCIsImEiOiJjbDJyeHJob2YwYnhwM2xtaG9zaDdnYTR4In0.Rh2bSS44c99BoDj2W7jjfw";
     //Default view is at TFHRC
     let default_center = [-77.150495, 38.955675];
-    ervMap = new mapboxgl.Map({
+    erv_map = new mapboxgl.Map({
         container: 'erv-map',
         style: 'mapbox://styles/mapbox/satellite-v9',
         center: default_center,
         zoom: 17
     });
-    ervMap.addControl(new mapboxgl.FullscreenControl());
+    erv_map.addControl(new mapboxgl.FullscreenControl());
 
     setInterval(() => {
         //Change View Point
-        ervMap.jumpTo({ 'center': data.features[0].geometry.coordinates.length == 0 ? default_center : data.features[0].geometry.coordinates, 'zoom': 17 });
+        erv_map.jumpTo({ 'center': data.features[0].geometry.coordinates.length == 0 ? default_center : data.features[0].geometry.coordinates, 'zoom': 17 });
     }, 2000);
 
-    ervMap.on('load', () => {
-        ervMap.addSource(ERV_ROUTE_SOURCE, {
+    erv_map.on('load', () => {
+        erv_map.addSource(ERV_ROUTE_SOURCE, {
             'type': 'geojson',
             'data': data
         });
 
-        ervMap.addLayer({
+        erv_map.addLayer({
             'id': ERV_ROUTE_SOURCE,
             'type': 'circle',
             'source': 'erv-route-trace',


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Renamed the global `map` variable to `ervMap` in the Emergency Response widget to avoid a redeclaration error caused by map conflicting with the built-in `Array.prototype.map` or other global/scoped `map` declarations. Without the fix, the Emergency Response UI does not render.

<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
